### PR TITLE
fix: remove useScrollViewOffset offset in favor of useAnimatedScrollHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,17 @@ React Native Header is a high-performance, cross-platform animated header compon
 - Compatible with [Expo Go](https://docs.expo.dev/) and [React Native CLI](https://github.com/react-native-community/cli) projects
 - Written in TypeScript
 
+## Supported dependency versions
+
+| This library | react-native | react-native-reanimated | react-native-safe-area-context | 
+| -- | -- | -- | -- |
+| 0.6.x | >= 0.65 | >= 2.0.0 | >= 4.1.0 |
+
 ## Prerequisites
 
 Before you can use `react-native-header`, you need to have the following libraries set up in your React Native project:
 
-- [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)  v2 or v3. **v1 is not supported.**
+- [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated)
 - [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context)
 
 If you haven't installed these libraries yet, please follow the installation instructions on their respective documentation pages.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ React Native Header is a high-performance, cross-platform animated header compon
 
 | This library | react-native | react-native-reanimated | react-native-safe-area-context | 
 | -- | -- | -- | -- |
-| 0.6.x | >= 0.65 | >= 2.0.0 | >= 4.1.0 |
+| 0.6.x | >= 0.65 | >= 2.11.0 | >= 4.1.0 |
 
 ## Prerequisites
 

--- a/src/components/containers/FlatList.tsx
+++ b/src/components/containers/FlatList.tsx
@@ -1,44 +1,42 @@
 import React from 'react';
-import { View, FlatList, FlatListProps, StyleSheet } from 'react-native';
+import { View, FlatListProps, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, { useAnimatedRef, AnimateProps } from 'react-native-reanimated';
 
 import FadingView from '../containers/FadingView';
 import { useScrollContainerLogic } from './useScrollContainerLogic';
-import type { DisallowedScrollContainerProps, SharedScrollContainerProps } from './types';
+import type { SharedScrollContainerProps } from './types';
 
 type AnimatedFlatListType<ItemT = any> = React.ComponentClass<
   AnimateProps<FlatListProps<ItemT>>,
   ItemT
 >;
 type AnimatedFlatListBaseProps<ItemT> = React.ComponentProps<AnimatedFlatListType<ItemT>>;
-type AnimatedFlatListProps<ItemT> = AnimatedFlatListBaseProps<ItemT> & {
-  children?: React.ReactNode;
-};
-const AnimatedFlatList: AnimatedFlatListType = Animated.createAnimatedComponent(FlatList);
+type AnimatedFlatListProps<ItemT> = AnimatedFlatListBaseProps<ItemT>;
 
-const AnimatedFlatListWithHeaders = <ItemT extends unknown>({
-  largeHeaderShown,
-  containerStyle,
-  LargeHeaderComponent,
-  largeHeaderContainerStyle,
-  HeaderComponent,
-  onLargeHeaderLayout,
-  onScrollBeginDrag,
-  onScrollEndDrag,
-  onMomentumScrollBegin,
-  onMomentumScrollEnd,
-  ignoreLeftSafeArea,
-  ignoreRightSafeArea,
-  disableAutoFixScroll,
-  // @ts-ignore - onScroll is not allowed, but we need to remove it from the props
-  onScroll: _unusedOnScroll,
-  ...rest
-}: Omit<AnimatedFlatListProps<ItemT>, DisallowedScrollContainerProps> &
-  SharedScrollContainerProps) => {
+const FlatListWithHeadersInputComp = <ItemT extends unknown>(
+  {
+    largeHeaderShown,
+    containerStyle,
+    LargeHeaderComponent,
+    largeHeaderContainerStyle,
+    HeaderComponent,
+    onLargeHeaderLayout,
+    onScrollBeginDrag,
+    onScrollEndDrag,
+    onMomentumScrollBegin,
+    onMomentumScrollEnd,
+    ignoreLeftSafeArea,
+    ignoreRightSafeArea,
+    disableAutoFixScroll,
+    /** At the moment, we will not allow overriding of this since the scrollHandler needs it. */
+    onScroll: _unusedOnScroll,
+    ...rest
+  }: AnimatedFlatListProps<ItemT> & SharedScrollContainerProps,
+  ref: React.Ref<AnimatedFlatListType<ItemT>>
+) => {
   const insets = useSafeAreaInsets();
   const scrollRef = useAnimatedRef<Animated.FlatList<ItemT>>();
-  // Need to use `any` here because useScrollViewOffset is not typed for Animated.FlatList
 
   const {
     scrollY,
@@ -64,8 +62,13 @@ const AnimatedFlatListWithHeaders = <ItemT extends unknown>({
       ]}
     >
       {HeaderComponent({ showNavBar })}
-      <AnimatedFlatList
-        ref={scrollRef}
+      <Animated.FlatList
+        ref={(_ref) => {
+          // @ts-ignore
+          scrollRef.current = _ref;
+          // @ts-ignore
+          if (ref) ref.current = _ref;
+        }}
         scrollEventThrottle={16}
         overScrollMode="auto"
         onScroll={scrollHandler}
@@ -107,6 +110,12 @@ const AnimatedFlatListWithHeaders = <ItemT extends unknown>({
   );
 };
 
-export default AnimatedFlatListWithHeaders;
+// The typecast is needed to make the component generic.
+const FlatListWithHeaders = React.forwardRef(FlatListWithHeadersInputComp) as <ItemT = any>(
+  props: AnimatedFlatListProps<ItemT> &
+    SharedScrollContainerProps & { ref?: React.Ref<Animated.FlatList<ItemT>> }
+) => React.ReactElement;
+
+export default FlatListWithHeaders;
 
 const styles = StyleSheet.create({ container: { flex: 1 } });

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Animated, { useAnimatedRef, useScrollViewOffset } from 'react-native-reanimated';
+import Animated, { useAnimatedRef } from 'react-native-reanimated';
 
 import FadingView from './FadingView';
 import { useScrollContainerLogic } from './useScrollContainerLogic';
-import type { SharedScrollContainerProps } from './types';
+import type { DisallowedScrollContainerProps, SharedScrollContainerProps } from './types';
 
 type AnimatedScrollViewProps = React.ComponentProps<typeof Animated.ScrollView> & {
   children?: React.ReactNode;
 };
 
 const AnimatedScrollViewWithHeaders: React.FC<
-  AnimatedScrollViewProps & SharedScrollContainerProps
+  Omit<AnimatedScrollViewProps, DisallowedScrollContainerProps> & SharedScrollContainerProps
 > = ({
   largeHeaderShown,
   containerStyle,
@@ -28,20 +28,26 @@ const AnimatedScrollViewWithHeaders: React.FC<
   onMomentumScrollEnd,
   disableAutoFixScroll,
   children,
+  // @ts-ignore - onScroll is not allowed, but we need to remove it from the props
+  onScroll: _unusedOnScroll,
   ...rest
 }) => {
   const insets = useSafeAreaInsets();
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
-  const scrollY = useScrollViewOffset(scrollRef);
 
-  const { showNavBar, largeHeaderHeight, largeHeaderOpacity, debouncedFixScroll } =
-    useScrollContainerLogic({
-      scrollRef,
-      scrollY,
-      largeHeaderShown,
-      disableAutoFixScroll,
-      largeHeaderExists: !!LargeHeaderComponent,
-    });
+  const {
+    scrollY,
+    showNavBar,
+    largeHeaderHeight,
+    largeHeaderOpacity,
+    scrollHandler,
+    debouncedFixScroll,
+  } = useScrollContainerLogic({
+    scrollRef,
+    largeHeaderShown,
+    disableAutoFixScroll,
+    largeHeaderExists: !!LargeHeaderComponent,
+  });
 
   return (
     <View
@@ -57,6 +63,7 @@ const AnimatedScrollViewWithHeaders: React.FC<
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
+        onScroll={scrollHandler}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -5,33 +5,34 @@ import Animated, { useAnimatedRef } from 'react-native-reanimated';
 
 import FadingView from './FadingView';
 import { useScrollContainerLogic } from './useScrollContainerLogic';
-import type { DisallowedScrollContainerProps, SharedScrollContainerProps } from './types';
+import type { SharedScrollContainerProps } from './types';
 
 type AnimatedScrollViewProps = React.ComponentProps<typeof Animated.ScrollView> & {
   children?: React.ReactNode;
 };
 
-const AnimatedScrollViewWithHeaders: React.FC<
-  Omit<AnimatedScrollViewProps, DisallowedScrollContainerProps> & SharedScrollContainerProps
-> = ({
-  largeHeaderShown,
-  containerStyle,
-  LargeHeaderComponent,
-  largeHeaderContainerStyle,
-  HeaderComponent,
-  onLargeHeaderLayout,
-  ignoreLeftSafeArea,
-  ignoreRightSafeArea,
-  onScrollBeginDrag,
-  onScrollEndDrag,
-  onMomentumScrollBegin,
-  onMomentumScrollEnd,
-  disableAutoFixScroll,
-  children,
-  // @ts-ignore - onScroll is not allowed, but we need to remove it from the props
-  onScroll: _unusedOnScroll,
-  ...rest
-}) => {
+const ScrollViewWithHeadersInputComp = (
+  {
+    largeHeaderShown,
+    containerStyle,
+    LargeHeaderComponent,
+    largeHeaderContainerStyle,
+    HeaderComponent,
+    onLargeHeaderLayout,
+    ignoreLeftSafeArea,
+    ignoreRightSafeArea,
+    onScrollBeginDrag,
+    onScrollEndDrag,
+    onMomentumScrollBegin,
+    onMomentumScrollEnd,
+    disableAutoFixScroll,
+    children,
+    /** At the moment, we will not allow overriding of this since the scrollHandler needs it. */
+    onScroll: _unusedOnScroll,
+    ...rest
+  }: AnimatedScrollViewProps & SharedScrollContainerProps,
+  ref: React.Ref<Animated.ScrollView>
+) => {
   const insets = useSafeAreaInsets();
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
 
@@ -60,7 +61,12 @@ const AnimatedScrollViewWithHeaders: React.FC<
     >
       {HeaderComponent({ showNavBar })}
       <Animated.ScrollView
-        ref={scrollRef}
+        ref={(_ref) => {
+          // @ts-ignore
+          scrollRef.current = _ref;
+          // @ts-ignore
+          if (ref) ref.current = _ref;
+        }}
         scrollEventThrottle={16}
         overScrollMode="auto"
         onScroll={scrollHandler}
@@ -102,6 +108,11 @@ const AnimatedScrollViewWithHeaders: React.FC<
   );
 };
 
-export default AnimatedScrollViewWithHeaders;
+const ScrollViewWithHeaders = React.forwardRef<
+  Animated.ScrollView,
+  AnimatedScrollViewProps & SharedScrollContainerProps
+>(ScrollViewWithHeadersInputComp);
+
+export default ScrollViewWithHeaders;
 
 const styles = StyleSheet.create({ container: { flex: 1 } });

--- a/src/components/containers/types.ts
+++ b/src/components/containers/types.ts
@@ -7,8 +7,6 @@ import type {
 } from 'react-native';
 import type Animated from 'react-native-reanimated';
 
-export type DisallowedScrollContainerProps = 'onScroll';
-
 /**
  * The props supplied to the large header component of this scroll container.
  */
@@ -115,4 +113,9 @@ export type SharedScrollContainerProps = {
    * Fires when scroll view has finished moving.
    */
   onMomentumScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  /**
+   * This property is not supported at the moment. If you would like to listen to
+   * scroll events, use the useScrollViewOffset hook with a ref.
+   */
+  onScroll?: React.ComponentProps<typeof Animated.ScrollView>['onScroll'];
 };

--- a/src/components/containers/types.ts
+++ b/src/components/containers/types.ts
@@ -7,6 +7,8 @@ import type {
 } from 'react-native';
 import type Animated from 'react-native-reanimated';
 
+export type DisallowedScrollContainerProps = 'onScroll';
+
 /**
  * The props supplied to the large header component of this scroll container.
  */

--- a/src/components/containers/useScrollContainerLogic.ts
+++ b/src/components/containers/useScrollContainerLogic.ts
@@ -5,6 +5,7 @@ import Animated, {
   useDerivedValue,
   useSharedValue,
   withTiming,
+  useAnimatedScrollHandler,
 } from 'react-native-reanimated';
 import { useDebouncedCallback } from 'use-debounce';
 import type { SharedScrollContainerProps } from './types';
@@ -19,12 +20,6 @@ interface UseScrollContainerLogicArgs {
    * @type {React.RefObject<Animated.ScrollView | Animated.FlatList<any>>}
    */
   scrollRef: React.RefObject<Animated.ScrollView | Animated.FlatList<any>>;
-  /**
-   * The scroll position of the scroll container.
-   *
-   * @type {Animated.SharedValue<number>}
-   */
-  scrollY: Animated.SharedValue<number>;
   /**
    * This is a hack to ensure that the larger repositions itself correctly.
    *
@@ -60,13 +55,17 @@ interface UseScrollContainerLogicArgs {
  */
 export const useScrollContainerLogic = ({
   scrollRef,
-  scrollY,
   largeHeaderShown,
   largeHeaderExists,
   disableAutoFixScroll = false,
   adjustmentOffset = 4,
 }: UseScrollContainerLogicArgs) => {
+  const scrollY = useSharedValue(0);
   const largeHeaderHeight = useSharedValue(0);
+
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    scrollY.value = event.contentOffset.y;
+  });
 
   const showNavBar = useDerivedValue(() => {
     if (!largeHeaderExists) return withTiming(scrollY.value <= 0 ? 0 : 1, { duration: 250 });
@@ -111,5 +110,12 @@ export const useScrollContainerLogic = ({
     }
   }, 50);
 
-  return { showNavBar, largeHeaderHeight, largeHeaderOpacity, debouncedFixScroll };
+  return {
+    scrollY,
+    showNavBar,
+    largeHeaderHeight,
+    largeHeaderOpacity,
+    scrollHandler,
+    debouncedFixScroll,
+  };
 };

--- a/src/components/headers/Header.tsx
+++ b/src/components/headers/Header.tsx
@@ -136,7 +136,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'flex-start',
     overflow: 'hidden',
-    gap: 4,
   },
   centerContainer: {
     flex: 1,
@@ -153,7 +152,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     paddingHorizontal: 8,
     overflow: 'hidden',
-    gap: 4,
   },
   noFlex: { display: 'none' },
 });


### PR DESCRIPTION
## Description

The internal scroll containers (i.e., ScrollView, FlatList, SectionList) have been modified to use the `useAnimatedScrollHandler` instead.

## Motivation and Context

The reason this change was made was because the previously-used hook `useScrollViewOffset` is [only available on react-native-reanimated >= 2.11.0](https://docs.swmansion.com/react-native-reanimated/docs/2.x/api/hooks/useScrollViewOffset).

## How Has This Been Tested?

Tested on example application.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have followed the guidelines in the README.md file.
- [ ] I have updated the documentation as necessary.
- [ ] My changes generate no new warnings.
