### PR TITLE
feat: absolute headers

### DIFF
--- a/example/src/navigation/AppNavigation.tsx
+++ b/example/src/navigation/AppNavigation.tsx
@@ -10,6 +10,7 @@ import {
   SimpleUsageScreen,
   SurfaceComponentUsageScreen,
   TwitterProfileScreen,
+  AbsoluteHeaderBlurSurface,
 } from '../screens';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -31,5 +32,9 @@ export default () => (
       component={SurfaceComponentUsageScreen}
     />
     <Stack.Screen name="TwitterProfileScreen" component={TwitterProfileScreen} />
+    <Stack.Screen
+      name="AbsoluteHeaderBlurSurfaceUsageScreen"
+      component={AbsoluteHeaderBlurSurface}
+    />
   </Stack.Navigator>
 );

--- a/example/src/navigation/types.ts
+++ b/example/src/navigation/types.ts
@@ -10,6 +10,7 @@ export type RootStackParamList = {
   SectionListUsageScreen: undefined;
   TwitterProfileScreen: undefined;
   HeaderSurfaceComponentUsageScreen: undefined;
+  AbsoluteHeaderBlurSurfaceUsageScreen: undefined;
 };
 
 // Overrides the typing for useNavigation in @react-navigation/native to support the internal
@@ -52,4 +53,9 @@ export type SurfaceComponentUsageScreenNavigationProps = NativeStackScreenProps<
 export type TwitterProfileScreenNavigationProps = NativeStackScreenProps<
   RootStackParamList,
   'TwitterProfileScreen'
+>;
+
+export type AbsoluteHeaderBlurSurfaceUsageScreenNavigationProps = NativeStackScreenProps<
+  RootStackParamList,
+  'AbsoluteHeaderBlurSurfaceUsageScreen'
 >;

--- a/example/src/screens/Home.tsx
+++ b/example/src/screens/Home.tsx
@@ -49,6 +49,11 @@ const SCREEN_LIST_CONFIG: ScreenConfigItem[] = [
     route: 'TwitterProfileScreen',
     description: 'Rebuilding the Twitter profile header with this library.',
   },
+  {
+    name: 'Absolute Header with Blurred Surface',
+    route: 'AbsoluteHeaderBlurSurfaceUsageScreen',
+    description: 'An example of an absolutely-positioned header with a BlurView surface.',
+  },
 ];
 
 const HeaderComponent: React.FC<ScrollHeaderProps> = ({ showNavBar }) => {
@@ -83,6 +88,7 @@ const Home: React.FC<HomeScreenNavigationProps> = ({ navigation }) => {
 
   return (
     <ScrollViewWithHeaders
+      disableAutoFixScroll
       HeaderComponent={HeaderComponent}
       LargeHeaderComponent={LargeHeaderComponent}
       contentContainerStyle={{ paddingBottom: bottom }}

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -8,3 +8,4 @@ export { default as FlashListUsageScreen } from './usage/FlashList';
 export { default as SectionListUsageScreen } from './usage/SectionList';
 export { default as SurfaceComponentUsageScreen } from './usage/SurfaceComponent';
 export { default as TwitterProfileScreen } from './usage/TwitterProfile';
+export { default as AbsoluteHeaderBlurSurface } from './usage/AbsoluteHeaderBlurSurface';

--- a/example/src/screens/usage/AbsoluteHeaderBlurSurface.tsx
+++ b/example/src/screens/usage/AbsoluteHeaderBlurSurface.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { AbsoluteHeaderBlurSurfaceUsageScreenNavigationProps } from '../../navigation';
+import {
+  FadingView,
+  Header,
+  LargeHeader,
+  ScalingView,
+  ScrollHeaderProps,
+  ScrollLargeHeaderProps,
+  ScrollViewWithHeaders,
+  SurfaceComponentProps,
+} from '@codeherence/react-native-header';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BlurView } from '@react-native-community/blur';
+import { BackButton } from '../../components';
+import { range } from '../../utils';
+
+const HeaderSurface: React.FC<SurfaceComponentProps> = ({ showNavBar }) => {
+  return (
+    <FadingView opacity={showNavBar} style={StyleSheet.absoluteFill}>
+      <BlurView style={StyleSheet.absoluteFill} blurType="light" />
+    </FadingView>
+  );
+};
+
+const HeaderComponent: React.FC<ScrollHeaderProps> = ({ showNavBar }) => {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Header
+      showNavBar={showNavBar}
+      noBottomBorder
+      headerStyle={{ height: 44 + insets.top }}
+      headerCenter={<Text style={styles.headerTitle}>react-native-header</Text>}
+      headerLeft={<BackButton />}
+      SurfaceComponent={HeaderSurface}
+    />
+  );
+};
+
+const LargeHeaderComponent: React.FC<ScrollLargeHeaderProps> = ({ scrollY }) => {
+  return (
+    <LargeHeader>
+      <ScalingView scrollY={scrollY} style={styles.leftHeader}>
+        <Text style={styles.title}>Large Header</Text>
+      </ScalingView>
+    </LargeHeader>
+  );
+};
+
+const TransparentSurface: React.FC<AbsoluteHeaderBlurSurfaceUsageScreenNavigationProps> = () => {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <ScrollViewWithHeaders
+      absoluteHeader
+      HeaderComponent={HeaderComponent}
+      LargeHeaderComponent={LargeHeaderComponent}
+      style={styles.container}
+      contentContainerStyle={{ paddingBottom: bottom + 12 }}
+    >
+      <View style={styles.boxes}>
+        {range({ end: 20 }).map((i) => (
+          <View key={`box-${i}`} style={i % 2 === 0 ? styles.redBox : styles.greenBox} />
+        ))}
+      </View>
+    </ScrollViewWithHeaders>
+  );
+};
+
+export default TransparentSurface;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    zIndex: -100,
+  },
+  contentContainer: {
+    paddingTop: 44,
+  },
+  redBox: {
+    backgroundColor: 'red',
+    height: 200,
+    width: 200,
+  },
+  greenBox: {
+    backgroundColor: 'green',
+    height: 200,
+    width: 200,
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  boxes: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  title: { fontSize: 32, fontWeight: 'bold' },
+  leftHeader: { gap: 2 },
+});

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -31,6 +31,10 @@ const ScrollViewWithHeadersInputComp = (
     children,
     /** At the moment, we will not allow overriding of this since the scrollHandler needs it. */
     onScroll: _unusedOnScroll,
+    absoluteHeader = false,
+    initialAbsoluteHeaderHeight = 0,
+    contentContainerStyle,
+    automaticallyAdjustsScrollIndicatorInsets,
     ...rest
   }: AnimatedScrollViewProps & SharedScrollContainerProps,
   ref: React.Ref<Animated.ScrollView | null>
@@ -46,11 +50,15 @@ const ScrollViewWithHeadersInputComp = (
     largeHeaderOpacity,
     scrollHandler,
     debouncedFixScroll,
+    absoluteHeaderHeight,
+    onAbsoluteHeaderLayout,
   } = useScrollContainerLogic({
     scrollRef,
     largeHeaderShown,
     disableAutoFixScroll,
     largeHeaderExists: !!LargeHeaderComponent,
+    absoluteHeader,
+    initialAbsoluteHeaderHeight,
   });
 
   return (
@@ -62,7 +70,7 @@ const ScrollViewWithHeadersInputComp = (
         !ignoreRightSafeArea && { paddingRight: insets.right },
       ]}
     >
-      {HeaderComponent({ showNavBar, scrollY })}
+      {!absoluteHeader && HeaderComponent({ showNavBar, scrollY })}
       <AnimatedScrollView
         ref={scrollRef}
         scrollEventThrottle={16}
@@ -85,6 +93,16 @@ const ScrollViewWithHeadersInputComp = (
           debouncedFixScroll();
           if (onMomentumScrollEnd) onMomentumScrollEnd(e);
         }}
+        contentContainerStyle={[
+          contentContainerStyle,
+          absoluteHeader ? { paddingTop: absoluteHeaderHeight } : undefined,
+        ]}
+        automaticallyAdjustsScrollIndicatorInsets={
+          automaticallyAdjustsScrollIndicatorInsets !== undefined
+            ? automaticallyAdjustsScrollIndicatorInsets
+            : !absoluteHeader
+        }
+        scrollIndicatorInsets={{ top: absoluteHeader ? absoluteHeaderHeight : 0 }}
         {...rest}
       >
         {LargeHeaderComponent ? (
@@ -102,6 +120,12 @@ const ScrollViewWithHeadersInputComp = (
         ) : null}
         {children}
       </AnimatedScrollView>
+
+      {absoluteHeader && (
+        <View style={styles.absoluteHeader} onLayout={onAbsoluteHeaderLayout}>
+          {HeaderComponent({ showNavBar, scrollY })}
+        </View>
+      )}
     </View>
   );
 };
@@ -113,4 +137,12 @@ const ScrollViewWithHeaders = React.forwardRef<
 
 export default ScrollViewWithHeaders;
 
-const styles = StyleSheet.create({ container: { flex: 1 } });
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  absoluteHeader: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    left: 0,
+  },
+});

--- a/src/components/containers/types.ts
+++ b/src/components/containers/types.ts
@@ -124,4 +124,15 @@ export type SharedScrollContainerProps = {
    * scroll events, use the useScrollViewOffset hook with a ref.
    */
   onScroll?: React.ComponentProps<typeof Animated.ScrollView>['onScroll'];
+  /**
+   * This property controls whether or not the header component is absolutely positioned.
+   * This is useful if you want to render a header component that allows for transparency.
+   */
+  absoluteHeader?: boolean;
+  /**
+   * This property is used when `absoluteHeader` is true. This is the initial height of the
+   * absolute header. Since the header's height is computed on its layout event, this is used
+   * to set the initial height of the header so that it doesn't jump when it is initially rendered.
+   */
+  initialAbsoluteHeaderHeight?: number;
 };

--- a/src/components/containers/useScrollContainerLogic.ts
+++ b/src/components/containers/useScrollContainerLogic.ts
@@ -1,3 +1,5 @@
+import { useCallback, useState } from 'react';
+import { LayoutChangeEvent } from 'react-native';
 import Animated, {
   interpolate,
   runOnUI,
@@ -45,6 +47,17 @@ interface UseScrollContainerLogicArgs {
    * @default false
    */
   disableAutoFixScroll?: boolean;
+  /**
+   * This property controls whether or not the header component is absolutely positioned.
+   * This is useful if you want to render a header component that allows for transparency.
+   */
+  absoluteHeader?: boolean;
+  /**
+   * This property is used when `absoluteHeader` is true. This is the initial height of the
+   * absolute header. Since the header's height is computed on its layout event, this is used
+   * to set the initial height of the header so that it doesn't jump when it is initially rendered.
+   */
+  initialAbsoluteHeaderHeight?: number;
 }
 
 /**
@@ -59,7 +72,10 @@ export const useScrollContainerLogic = ({
   largeHeaderExists,
   disableAutoFixScroll = false,
   adjustmentOffset = 4,
+  absoluteHeader = false,
+  initialAbsoluteHeaderHeight = 0,
 }: UseScrollContainerLogicArgs) => {
+  const [absoluteHeaderHeight, setAbsoluteHeaderHeight] = useState(initialAbsoluteHeaderHeight);
   const scrollY = useSharedValue(0);
   const largeHeaderHeight = useSharedValue(0);
 
@@ -110,6 +126,15 @@ export const useScrollContainerLogic = ({
     }
   }, 50);
 
+  const onAbsoluteHeaderLayout = useCallback(
+    (e: LayoutChangeEvent) => {
+      if (absoluteHeader) {
+        setAbsoluteHeaderHeight(e.nativeEvent.layout.height);
+      }
+    },
+    [absoluteHeader]
+  );
+
   return {
     scrollY,
     showNavBar,
@@ -117,5 +142,7 @@ export const useScrollContainerLogic = ({
     largeHeaderOpacity,
     scrollHandler,
     debouncedFixScroll,
+    absoluteHeaderHeight,
+    onAbsoluteHeaderLayout,
   };
 };


### PR DESCRIPTION
## Description

This PR introduces two new props to all scroll containers: `absoluteHeader` and `initialAbsoluteHeaderHeight`. These props allow you to position the header absolutely, so that the scroll container content can scroll behind the header.

## Motivation and Context

iOS native headers allow for a blurred header above a scroll container. As the user scrolls, the content below can be seen through the blurred surface. These changes were made to introduce that functionality to the scroll containers exported in this library.

## How Has This Been Tested?

These changes have been tested via the example application, and all other examples are working as expected. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have followed the guidelines in the README.md file.
- [ ] I have updated the documentation as necessary.
- [ ] My changes generate no new warnings.

## Screenshots

https://github.com/codeherence/react-native-header/assets/128341688/f99a6cb3-a8e7-42f5-926f-abfd26aa4538

## Additional Notes

The reason for the changes in API for this feature is because a `BlurView` specifically requires itself to be [defined after the scroll container to work properly](https://github.com/Kureev/react-native-blur/issues/317#issuecomment-1032584948).