### PR TITLE
feat: better support inverted virtualized lists

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,6 +8,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@ngneat/falso": "^6.4.0",
     "@react-native-community/blur": "^4.3.0",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",

--- a/example/src/navigation/AppNavigation.tsx
+++ b/example/src/navigation/AppNavigation.tsx
@@ -12,6 +12,7 @@ import {
   TwitterProfileScreen,
   AbsoluteHeaderBlurSurfaceUsageScreen,
   ArbitraryYTransitionHeaderUsageScreen,
+  InvertedUsageScreen,
 } from '../screens';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -28,6 +29,7 @@ export default () => (
     <Stack.Screen name="FlatListUsageScreen" component={FlatListUsageScreen} />
     <Stack.Screen name="FlashListUsageScreen" component={FlashListUsageScreen} />
     <Stack.Screen name="SectionListUsageScreen" component={SectionListUsageScreen} />
+    <Stack.Screen name="InvertedUsageScreen" component={InvertedUsageScreen} />
     <Stack.Screen
       name="HeaderSurfaceComponentUsageScreen"
       component={SurfaceComponentUsageScreen}

--- a/example/src/navigation/types.ts
+++ b/example/src/navigation/types.ts
@@ -12,6 +12,7 @@ export type RootStackParamList = {
   HeaderSurfaceComponentUsageScreen: undefined;
   AbsoluteHeaderBlurSurfaceUsageScreen: undefined;
   ArbitraryYTransitionHeaderUsageScreen: undefined;
+  InvertedUsageScreen: undefined;
 };
 
 // Overrides the typing for useNavigation in @react-navigation/native to support the internal
@@ -64,4 +65,9 @@ export type AbsoluteHeaderBlurSurfaceUsageScreenNavigationProps = NativeStackScr
 export type ArbitraryYTransitionHeaderUsageScreenNavigationProps = NativeStackScreenProps<
   RootStackParamList,
   'ArbitraryYTransitionHeaderUsageScreen'
+>;
+
+export type InvertedUsageScreenNavigationProps = NativeStackScreenProps<
+  RootStackParamList,
+  'InvertedUsageScreen'
 >;

--- a/example/src/screens/Home.tsx
+++ b/example/src/screens/Home.tsx
@@ -39,6 +39,11 @@ const SCREEN_LIST_CONFIG: ScreenConfigItem[] = [
     description: "A simple example of the library's SectionList.",
   },
   {
+    name: 'Inverted Example',
+    route: 'InvertedUsageScreen',
+    description: "A simple example of the library's Inverted FlatList.",
+  },
+  {
     name: 'Header SurfaceComponent Interpolation',
     route: 'HeaderSurfaceComponentUsageScreen',
     description:

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -6,6 +6,7 @@ export { default as SimpleUsageScreen } from './usage/Simple';
 export { default as FlatListUsageScreen } from './usage/FlatList';
 export { default as FlashListUsageScreen } from './usage/FlashList';
 export { default as SectionListUsageScreen } from './usage/SectionList';
+export { default as InvertedUsageScreen } from './usage/Inverted';
 export { default as SurfaceComponentUsageScreen } from './usage/SurfaceComponent';
 export { default as TwitterProfileScreen } from './usage/TwitterProfile';
 export { default as AbsoluteHeaderBlurSurfaceUsageScreen } from './usage/AbsoluteHeaderBlurSurface';

--- a/example/src/screens/usage/Inverted.tsx
+++ b/example/src/screens/usage/Inverted.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { randParagraph, randUuid } from '@ngneat/falso';
+import { BlurView } from '@react-native-community/blur';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import {
+  Header,
+  ScrollHeaderProps,
+  FlatListWithHeaders,
+  SurfaceComponentProps,
+} from '@codeherence/react-native-header';
+import { Avatar, BackButton } from '../../components';
+import { RANDOM_IMAGE_NUM } from '../../constants';
+import { range } from '../../utils';
+import type { InvertedUsageScreenNavigationProps } from '../../navigation';
+
+const HeaderSurface: React.FC<SurfaceComponentProps> = () => {
+  return <BlurView style={StyleSheet.absoluteFill} blurType="chromeMaterialDark" />;
+};
+
+const HeaderComponent: React.FC<ScrollHeaderProps> = ({ showNavBar }) => {
+  const navigation = useNavigation();
+  const onPressProfile = () => navigation.navigate('Profile');
+
+  return (
+    <Header
+      showNavBar={showNavBar}
+      noBottomBorder
+      headerCenterFadesIn={false}
+      headerCenter={
+        <Text style={styles.navBarTitle} numberOfLines={1}>
+          Elon Musk
+        </Text>
+      }
+      headerRight={
+        <TouchableOpacity onPress={onPressProfile}>
+          <Avatar size="sm" source={{ uri: `https://i.pravatar.cc/128?img=${RANDOM_IMAGE_NUM}` }} />
+        </TouchableOpacity>
+      }
+      headerLeft={<BackButton color="white" />}
+      SurfaceComponent={HeaderSurface}
+    />
+  );
+};
+
+interface ChatMessage {
+  id: string;
+  message: string;
+  type: 'sent' | 'received';
+}
+
+const data: ChatMessage[] = range({ end: 100 }).map((i) => {
+  const id = randUuid();
+  const message = randParagraph();
+  const type = i % 2 === 0 ? 'sent' : 'received';
+
+  return { id, message, type };
+});
+
+const ChatMessage: React.FC<ChatMessage> = ({ message, type }) => {
+  return (
+    <View style={type === 'sent' ? styles.sentMessageContainer : styles.receivedMessageContainer}>
+      <Text style={styles.messageText}>{message}</Text>
+    </View>
+  );
+};
+
+const Inverted: React.FC<InvertedUsageScreenNavigationProps> = () => {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <>
+      <StatusBar style="light" />
+      <FlatListWithHeaders
+        data={data}
+        renderItem={({ item }) => <ChatMessage {...item} />}
+        HeaderComponent={HeaderComponent}
+        keyExtractor={(item) => item.id}
+        inverted
+        absoluteHeader
+        containerStyle={styles.container}
+        contentContainerStyle={[styles.contentContainer, { paddingTop: bottom }]}
+        showsVerticalScrollIndicator
+        indicatorStyle={'white'}
+      />
+    </>
+  );
+};
+
+export default Inverted;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'black',
+  },
+  contentContainer: {
+    backgroundColor: 'black',
+    paddingHorizontal: 12,
+  },
+  navBarTitle: { fontSize: 16, fontWeight: 'bold', color: 'white' },
+  messageText: {
+    color: 'white',
+  },
+  sentMessageContainer: {
+    backgroundColor: '#186BE7',
+    alignSelf: 'flex-start',
+    borderRadius: 12,
+    maxWidth: '75%',
+    padding: 12,
+    marginVertical: 12,
+  },
+  receivedMessageContainer: {
+    backgroundColor: '#1F2329',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-end',
+    alignSelf: 'flex-end',
+    borderRadius: 12,
+    maxWidth: '75%',
+    padding: 12,
+    marginVertical: 12,
+  },
+  separator: {
+    height: 24,
+  },
+});

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1715,6 +1715,14 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@ngneat/falso@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@ngneat/falso/-/falso-6.4.0.tgz#7ed98a95ab2a2dc39b0a0d317fe8c24512869edc"
+  integrity sha512-f6r036h2fX/AoHw1eV2t8+qWQwrbSrozs3zXMhhwoO7SJBc+DGMxRWEhFeYIinfwx0uhUH8ggx5+PDLzYESLOA==
+  dependencies:
+    seedrandom "3.0.5"
+    uuid "8.3.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -9704,6 +9712,11 @@ schema-utils@^3.0.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+seedrandom@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -10990,6 +11003,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@8.3.2, uuid@^8.0.0, uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -10999,11 +11017,6 @@ uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
-uuid@^8.0.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 valid-url@~1.0.9:
   version "1.0.9"

--- a/src/components/containers/FlashList.tsx
+++ b/src/components/containers/FlashList.tsx
@@ -42,6 +42,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     headerFadeInThreshold = 1,
     disableLargeHeaderFadeAnim = false,
     scrollIndicatorInsets = {},
+    inverted,
     ...rest
   }: AnimatedFlashListType<ItemT>,
   ref: React.Ref<FlashList<ItemT>>
@@ -57,8 +58,8 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     largeHeaderOpacity,
     scrollHandler,
     debouncedFixScroll,
-    absoluteHeaderHeight,
     onAbsoluteHeaderLayout,
+    scrollViewAdjustments,
   } = useScrollContainerLogic({
     scrollRef,
     largeHeaderShown,
@@ -67,6 +68,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     absoluteHeader,
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
+    inverted: !!inverted,
   });
 
   return (
@@ -101,12 +103,11 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
           debouncedFixScroll();
           if (onMomentumScrollEnd) onMomentumScrollEnd(e);
         }}
-        // eslint-disable-next-line react-native/no-inline-styles
         contentContainerStyle={{
           // The reason why we do this is because FlashList does not support an array of
           // styles (will throw a warning when you supply one).
+          ...scrollViewAdjustments.contentContainerStyle,
           ...contentContainerStyle,
-          paddingTop: absoluteHeader ? absoluteHeaderHeight : 0,
         }}
         automaticallyAdjustsScrollIndicatorInsets={
           automaticallyAdjustsScrollIndicatorInsets !== undefined
@@ -114,7 +115,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
             : !absoluteHeader
         }
         scrollIndicatorInsets={{
-          top: absoluteHeader ? absoluteHeaderHeight : 0,
+          ...scrollViewAdjustments.scrollIndicatorInsets,
           ...scrollIndicatorInsets,
         }}
         ListHeaderComponent={
@@ -138,6 +139,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
             </View>
           ) : undefined
         }
+        inverted={inverted}
         {...rest}
       />
 

--- a/src/components/containers/FlatList.tsx
+++ b/src/components/containers/FlatList.tsx
@@ -38,6 +38,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     headerFadeInThreshold = 1,
     disableLargeHeaderFadeAnim = false,
     scrollIndicatorInsets = {},
+    inverted,
     ...rest
   }: AnimatedFlatListProps<ItemT> & SharedScrollContainerProps,
   ref: React.Ref<Animated.FlatList<ItemT> | null>
@@ -53,8 +54,8 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     largeHeaderOpacity,
     scrollHandler,
     debouncedFixScroll,
-    absoluteHeaderHeight,
     onAbsoluteHeaderLayout,
+    scrollViewAdjustments,
   } = useScrollContainerLogic({
     scrollRef,
     largeHeaderShown,
@@ -63,6 +64,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     absoluteHeader,
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
+    inverted: !!inverted,
   });
 
   return (
@@ -98,10 +100,10 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
           if (onMomentumScrollEnd) onMomentumScrollEnd(e);
         }}
         contentContainerStyle={[
+          scrollViewAdjustments.contentContainerStyle,
           // @ts-ignore
           // Unfortunately there are issues with Reanimated typings, so will ignore for now.
           contentContainerStyle,
-          absoluteHeader ? { paddingTop: absoluteHeaderHeight } : undefined,
         ]}
         automaticallyAdjustsScrollIndicatorInsets={
           automaticallyAdjustsScrollIndicatorInsets !== undefined
@@ -109,7 +111,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
             : !absoluteHeader
         }
         scrollIndicatorInsets={{
-          top: absoluteHeader ? absoluteHeaderHeight : 0,
+          ...scrollViewAdjustments.scrollIndicatorInsets,
           ...scrollIndicatorInsets,
         }}
         ListHeaderComponent={
@@ -133,6 +135,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
             </View>
           ) : undefined
         }
+        inverted={inverted}
         {...rest}
       />
 

--- a/src/components/containers/SectionList.tsx
+++ b/src/components/containers/SectionList.tsx
@@ -42,6 +42,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     headerFadeInThreshold = 1,
     disableLargeHeaderFadeAnim = false,
     scrollIndicatorInsets = {},
+    inverted,
     ...rest
   }: AnimatedSectionListType<ItemT, SectionT>,
   ref: React.Ref<Animated.ScrollView>
@@ -57,8 +58,8 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     largeHeaderOpacity,
     scrollHandler,
     debouncedFixScroll,
-    absoluteHeaderHeight,
     onAbsoluteHeaderLayout,
+    scrollViewAdjustments,
   } = useScrollContainerLogic({
     scrollRef,
     largeHeaderShown,
@@ -67,6 +68,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     absoluteHeader,
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
+    inverted: !!inverted,
   });
 
   return (
@@ -102,10 +104,10 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
           if (onMomentumScrollEnd) onMomentumScrollEnd(e);
         }}
         contentContainerStyle={[
+          scrollViewAdjustments.contentContainerStyle,
           // @ts-ignore
           // Unfortunately there are issues with Reanimated typings, so will ignore for now.
           contentContainerStyle,
-          absoluteHeader ? { paddingTop: absoluteHeaderHeight } : undefined,
         ]}
         automaticallyAdjustsScrollIndicatorInsets={
           automaticallyAdjustsScrollIndicatorInsets !== undefined
@@ -113,7 +115,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
             : !absoluteHeader
         }
         scrollIndicatorInsets={{
-          top: absoluteHeader ? absoluteHeaderHeight : 0,
+          ...scrollViewAdjustments.scrollIndicatorInsets,
           ...scrollIndicatorInsets,
         }}
         ListHeaderComponent={
@@ -137,6 +139,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
             </View>
           ) : undefined
         }
+        inverted={inverted}
         {...rest}
       />
 

--- a/src/components/containers/useScrollContainerLogic.ts
+++ b/src/components/containers/useScrollContainerLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { LayoutChangeEvent } from 'react-native';
 import Animated, {
   interpolate,
@@ -66,6 +66,10 @@ interface UseScrollContainerLogicArgs {
    * @default 1
    */
   headerFadeInThreshold?: number;
+  /**
+   * Whether or not the scroll container is inverted.
+   */
+  inverted?: boolean;
 }
 
 /**
@@ -83,6 +87,7 @@ export const useScrollContainerLogic = ({
   absoluteHeader = false,
   initialAbsoluteHeaderHeight = 0,
   headerFadeInThreshold = 1,
+  inverted,
 }: UseScrollContainerLogicArgs) => {
   const [absoluteHeaderHeight, setAbsoluteHeaderHeight] = useState(initialAbsoluteHeaderHeight);
   const scrollY = useSharedValue(0);
@@ -100,17 +105,13 @@ export const useScrollContainerLogic = ({
     if (largeHeaderShown) {
       largeHeaderShown.value = withTiming(
         scrollY.value <= largeHeaderHeight.value * headerFadeInThreshold - adjustmentOffset ? 0 : 1,
-        {
-          duration: 250,
-        }
+        { duration: 250 }
       );
     }
 
     return withTiming(
       scrollY.value <= largeHeaderHeight.value * headerFadeInThreshold - adjustmentOffset ? 0 : 1,
-      {
-        duration: 250,
-      }
+      { duration: 250 }
     );
   }, [largeHeaderExists]);
 
@@ -147,6 +148,19 @@ export const useScrollContainerLogic = ({
     [absoluteHeader]
   );
 
+  const scrollViewAdjustments = useMemo(() => {
+    return {
+      scrollIndicatorInsets: {
+        top: absoluteHeader && !inverted ? absoluteHeaderHeight : 0,
+        bottom: absoluteHeader && inverted ? absoluteHeaderHeight : 0,
+      },
+      contentContainerStyle: {
+        paddingTop: absoluteHeader && !inverted ? absoluteHeaderHeight : 0,
+        paddingBottom: absoluteHeader && inverted ? absoluteHeaderHeight : 0,
+      },
+    };
+  }, [inverted, absoluteHeaderHeight, absoluteHeader]);
+
   return {
     scrollY,
     showNavBar,
@@ -156,5 +170,6 @@ export const useScrollContainerLogic = ({
     debouncedFixScroll,
     absoluteHeaderHeight,
     onAbsoluteHeaderLayout,
+    scrollViewAdjustments,
   };
 };


### PR DESCRIPTION
## Description

Introduced partial support for the `inverted` prop on virtualized lists.

## Motivation and Context

Changes were made since the `inverted` prop caused "absoluteHeaders" to be wrongly adjusted.

## How Has This Been Tested?

A new example was added to the application to better track this functionality.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have followed the guidelines in the README.md file.
- [x] I have updated the documentation as necessary.
- [x] My changes generate no new warnings.

## Screenshots

https://github.com/codeherence/react-native-header/assets/128341688/370bd77b-0375-4fa6-b022-4cb6e4f98652

