### PR TITLE
feat: use user-provided onScroll

### DIFF
--- a/docs/docs/03-api-reference/01-scroll-view-with-headers.mdx
+++ b/docs/docs/03-api-reference/01-scroll-view-with-headers.mdx
@@ -112,3 +112,22 @@ Defaults to `1`.
 Whether or not the LargeHeaderComponent should fade in and out. Defaults to `false`.
 
 **Note**: This is only available in version >= 0.10.0.
+
+### onScrollWorklet
+
+A custom worklet that allows custom tracking scroll container's
+state (i.e., its scroll contentInset, contentOffset, etc.). Please
+ensure that this function is a [worklet](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/).
+
+Since the library uses the `onScroll` prop to handle animations internally and [reanimated
+does not currently allow for multiple onScroll handlers](https://github.com/software-mansion/react-native-reanimated/discussions/1763),
+you must use this property to track the state of the scroll container's state.
+
+An example is shown below:
+
+```tsx
+const scrollHandlerWorklet = (evt: NativeScrollEvent) => {
+  'worklet';
+  console.log('offset: ', evt.contentOffset);
+};
+```

--- a/docs/docs/03-api-reference/02-flat-list-with-headers.mdx
+++ b/docs/docs/03-api-reference/02-flat-list-with-headers.mdx
@@ -112,3 +112,22 @@ Defaults to `1`.
 Whether or not the LargeHeaderComponent should fade in and out. Defaults to `false`.
 
 **Note**: This is only available in version >= 0.10.0.
+
+### onScrollWorklet
+
+A custom worklet that allows custom tracking scroll container's
+state (i.e., its scroll contentInset, contentOffset, etc.). Please
+ensure that this function is a [worklet](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/).
+
+Since the library uses the `onScroll` prop to handle animations internally and [reanimated
+does not currently allow for multiple onScroll handlers](https://github.com/software-mansion/react-native-reanimated/discussions/1763),
+you must use this property to track the state of the scroll container's state.
+
+An example is shown below:
+
+```tsx
+const scrollHandlerWorklet = (evt: NativeScrollEvent) => {
+  'worklet';
+  console.log('offset: ', evt.contentOffset);
+};
+```

--- a/docs/docs/03-api-reference/03-section-list-with-headers.mdx
+++ b/docs/docs/03-api-reference/03-section-list-with-headers.mdx
@@ -112,3 +112,22 @@ Defaults to `1`.
 Whether or not the LargeHeaderComponent should fade in and out. Defaults to `false`.
 
 **Note**: This is only available in version >= 0.10.0.
+
+### onScrollWorklet
+
+A custom worklet that allows custom tracking scroll container's
+state (i.e., its scroll contentInset, contentOffset, etc.). Please
+ensure that this function is a [worklet](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/).
+
+Since the library uses the `onScroll` prop to handle animations internally and [reanimated
+does not currently allow for multiple onScroll handlers](https://github.com/software-mansion/react-native-reanimated/discussions/1763),
+you must use this property to track the state of the scroll container's state.
+
+An example is shown below:
+
+```tsx
+const scrollHandlerWorklet = (evt: NativeScrollEvent) => {
+  'worklet';
+  console.log('offset: ', evt.contentOffset);
+};
+```

--- a/docs/docs/03-api-reference/04-flash-list-with-headers.mdx
+++ b/docs/docs/03-api-reference/04-flash-list-with-headers.mdx
@@ -117,3 +117,22 @@ Defaults to `1`.
 Whether or not the LargeHeaderComponent should fade in and out. Defaults to `false`.
 
 **Note**: This is only available in version >= 0.10.0.
+
+### onScrollWorklet
+
+A custom worklet that allows custom tracking scroll container's
+state (i.e., its scroll contentInset, contentOffset, etc.). Please
+ensure that this function is a [worklet](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/).
+
+Since the library uses the `onScroll` prop to handle animations internally and [reanimated
+does not currently allow for multiple onScroll handlers](https://github.com/software-mansion/react-native-reanimated/discussions/1763),
+you must use this property to track the state of the scroll container's state.
+
+An example is shown below:
+
+```tsx
+const scrollHandlerWorklet = (evt: NativeScrollEvent) => {
+  'worklet';
+  console.log('offset: ', evt.contentOffset);
+};
+```

--- a/example/src/navigation/AppNavigation.tsx
+++ b/example/src/navigation/AppNavigation.tsx
@@ -13,6 +13,7 @@ import {
   AbsoluteHeaderBlurSurfaceUsageScreen,
   ArbitraryYTransitionHeaderUsageScreen,
   InvertedUsageScreen,
+  CustomOnScrollWorkletUsageScreen,
 } from '../screens';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -42,6 +43,10 @@ export default () => (
     <Stack.Screen
       name="ArbitraryYTransitionHeaderUsageScreen"
       component={ArbitraryYTransitionHeaderUsageScreen}
+    />
+    <Stack.Screen
+      name="CustomOnScrollWorkletUsageScreen"
+      component={CustomOnScrollWorkletUsageScreen}
     />
   </Stack.Navigator>
 );

--- a/example/src/navigation/types.ts
+++ b/example/src/navigation/types.ts
@@ -13,6 +13,7 @@ export type RootStackParamList = {
   AbsoluteHeaderBlurSurfaceUsageScreen: undefined;
   ArbitraryYTransitionHeaderUsageScreen: undefined;
   InvertedUsageScreen: undefined;
+  CustomOnScrollWorkletUsageScreen: undefined;
 };
 
 // Overrides the typing for useNavigation in @react-navigation/native to support the internal
@@ -70,4 +71,9 @@ export type ArbitraryYTransitionHeaderUsageScreenNavigationProps = NativeStackSc
 export type InvertedUsageScreenNavigationProps = NativeStackScreenProps<
   RootStackParamList,
   'InvertedUsageScreen'
+>;
+
+export type CustomOnScrollWorkletUsageScreenNavigationProps = NativeStackScreenProps<
+  RootStackParamList,
+  'CustomOnScrollWorkletUsageScreen'
 >;

--- a/example/src/screens/Home.tsx
+++ b/example/src/screens/Home.tsx
@@ -65,6 +65,12 @@ const SCREEN_LIST_CONFIG: ScreenConfigItem[] = [
     description:
       'An example of a header that transitions based on the scroll position of the ScrollView, instead of passing the height of the large header before animating.',
   },
+  {
+    name: 'Custom onScroll Worklet Example',
+    route: 'CustomOnScrollWorkletUsageScreen',
+    description:
+      "A simple example with a custom worklet that tracks the scroll container's offset.",
+  },
 ];
 
 const HeaderComponent: React.FC<ScrollHeaderProps> = ({ showNavBar }) => {

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -11,3 +11,4 @@ export { default as SurfaceComponentUsageScreen } from './usage/SurfaceComponent
 export { default as TwitterProfileScreen } from './usage/TwitterProfile';
 export { default as AbsoluteHeaderBlurSurfaceUsageScreen } from './usage/AbsoluteHeaderBlurSurface';
 export { default as ArbitraryYTransitionHeaderUsageScreen } from './usage/ArbitraryYTransitionHeader';
+export { default as CustomOnScrollWorkletUsageScreen } from './usage/CustomWorklet';

--- a/example/src/screens/usage/CustomWorklet.tsx
+++ b/example/src/screens/usage/CustomWorklet.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+import { NativeScrollEvent, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { Header, LargeHeader, ScrollViewWithHeaders } from '@codeherence/react-native-header';
+import type { ScrollHeaderProps, ScrollLargeHeaderProps } from '@codeherence/react-native-header';
+import { range } from '../../utils';
+import { Avatar, BackButton } from '../../components';
+import { RANDOM_IMAGE_NUM } from '../../constants';
+import type { CustomOnScrollWorkletUsageScreenNavigationProps } from '../../navigation';
+
+const HeaderComponent: React.FC<ScrollHeaderProps> = ({ showNavBar }) => {
+  const navigation = useNavigation();
+  const onPressProfile = () => navigation.navigate('Profile');
+
+  return (
+    <Header
+      showNavBar={showNavBar}
+      headerCenterFadesIn={false}
+      headerCenter={
+        <Text style={styles.navBarTitle} numberOfLines={1}>
+          Header
+        </Text>
+      }
+      headerRight={
+        <TouchableOpacity onPress={onPressProfile}>
+          <Avatar size="sm" source={{ uri: `https://i.pravatar.cc/128?img=${RANDOM_IMAGE_NUM}` }} />
+        </TouchableOpacity>
+      }
+      headerRightFadesIn
+      headerLeft={<BackButton />}
+    />
+  );
+};
+
+const LargeHeaderComponent: React.FC<ScrollLargeHeaderProps> = () => {
+  const navigation = useNavigation();
+  const onPressProfile = () => navigation.navigate('Profile');
+
+  return (
+    <LargeHeader headerStyle={styles.largeHeaderStyle}>
+      <TouchableOpacity onPress={onPressProfile}>
+        <Avatar size="sm" source={{ uri: `https://i.pravatar.cc/128?img=${RANDOM_IMAGE_NUM}` }} />
+      </TouchableOpacity>
+    </LargeHeader>
+  );
+};
+
+const CustomWorklet: React.FC<CustomOnScrollWorkletUsageScreenNavigationProps> = () => {
+  const { bottom } = useSafeAreaInsets();
+
+  const data = useMemo(() => range({ end: 100 }), []);
+
+  // Example worklet that can be used to track the scroll container's state.
+  const scrollHandlerWorklet = (evt: NativeScrollEvent) => {
+    'worklet';
+    console.log('offset: ', evt.contentOffset);
+  };
+
+  return (
+    <ScrollViewWithHeaders
+      HeaderComponent={HeaderComponent}
+      LargeHeaderComponent={LargeHeaderComponent}
+      contentContainerStyle={{ paddingBottom: bottom }}
+      onScrollWorklet={scrollHandlerWorklet}
+    >
+      <View style={styles.children}>
+        {data.map((i) => (
+          <Text key={`text-${i}`}>Scroll to see header animation</Text>
+        ))}
+      </View>
+    </ScrollViewWithHeaders>
+  );
+};
+
+export default CustomWorklet;
+
+const styles = StyleSheet.create({
+  children: { marginTop: 16, paddingHorizontal: 16 },
+  navBarTitle: { fontSize: 16, fontWeight: 'bold' },
+  largeHeaderStyle: { flexDirection: 'row-reverse' },
+});

--- a/src/components/containers/FlashList.tsx
+++ b/src/components/containers/FlashList.tsx
@@ -28,12 +28,13 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     onLargeHeaderLayout,
     onScrollBeginDrag,
     onScrollEndDrag,
+    onScrollWorklet,
     onMomentumScrollBegin,
     onMomentumScrollEnd,
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
-    onScroll,
+    onScroll: _unusedOnScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
     contentContainerStyle = {},
@@ -68,6 +69,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
     inverted: !!inverted,
+    onScrollWorklet,
   });
 
   return (
@@ -84,10 +86,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={(e) => {
-          scrollHandler(e);
-          if (onScroll) onScroll(e);
-        }}
+        onScroll={scrollHandler}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/FlashList.tsx
+++ b/src/components/containers/FlashList.tsx
@@ -33,8 +33,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
-    /** At the moment, we will not allow overriding of this since the scrollHandler needs it. */
-    onScroll: _unusedOnScroll,
+    onScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
     contentContainerStyle = {},
@@ -85,7 +84,10 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={scrollHandler}
+        onScroll={(e) => {
+          scrollHandler(e);
+          if (onScroll) onScroll(e);
+        }}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/FlashList.tsx
+++ b/src/components/containers/FlashList.tsx
@@ -18,6 +18,8 @@ const AnimatedFlashList = Animated.createAnimatedComponent(FlashList) as React.C
   unknown
 >;
 
+type FlashListWithHeadersProps<ItemT> = Omit<AnimatedFlashListType<ItemT>, 'onScroll'>;
+
 const FlashListWithHeadersInputComp = <ItemT extends any = any>(
   {
     largeHeaderShown,
@@ -34,6 +36,8 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
+    // We use this to ensure that the onScroll property isn't accidentally used.
+    // @ts-ignore
     onScroll: _unusedOnScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
@@ -44,9 +48,15 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     scrollIndicatorInsets = {},
     inverted,
     ...rest
-  }: AnimatedFlashListType<ItemT>,
+  }: FlashListWithHeadersProps<ItemT>,
   ref: React.Ref<FlashList<ItemT>>
 ) => {
+  if (_unusedOnScroll) {
+    throw new Error(
+      "The 'onScroll' property is not supported. Please use onScrollWorklet to track the scroll container's state."
+    );
+  }
+
   const insets = useSafeAreaInsets();
   const scrollRef = useAnimatedRef<any>();
   useImperativeHandle(ref, () => scrollRef.current);
@@ -155,7 +165,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
 
 // The typecast is needed to make the component generic.
 const FlashListWithHeaders = React.forwardRef(FlashListWithHeadersInputComp) as <ItemT = any>(
-  props: AnimatedFlashListType<ItemT> & { ref?: React.Ref<FlashList<ItemT>> }
+  props: FlashListWithHeadersProps<ItemT> & { ref?: React.Ref<FlashList<ItemT>> }
 ) => React.ReactElement;
 
 export default FlashListWithHeaders;

--- a/src/components/containers/FlatList.tsx
+++ b/src/components/containers/FlatList.tsx
@@ -24,12 +24,13 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     onLargeHeaderLayout,
     onScrollBeginDrag,
     onScrollEndDrag,
+    onScrollWorklet,
     onMomentumScrollBegin,
     onMomentumScrollEnd,
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
-    onScroll,
+    onScroll: _unusedOnScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
     contentContainerStyle,
@@ -64,6 +65,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
     inverted: !!inverted,
+    onScrollWorklet,
   });
 
   return (
@@ -80,10 +82,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={(e) => {
-          scrollHandler(e);
-          if (onScroll) onScroll(e);
-        }}
+        onScroll={scrollHandler}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/FlatList.tsx
+++ b/src/components/containers/FlatList.tsx
@@ -29,8 +29,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
-    /** At the moment, we will not allow overriding of this since the scrollHandler needs it. */
-    onScroll: _unusedOnScroll,
+    onScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
     contentContainerStyle,
@@ -81,7 +80,10 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={scrollHandler}
+        onScroll={(e) => {
+          scrollHandler(e);
+          if (onScroll) onScroll(e);
+        }}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/FlatList.tsx
+++ b/src/components/containers/FlatList.tsx
@@ -14,6 +14,11 @@ type AnimatedFlatListType<ItemT = any> = React.ComponentClass<
 type AnimatedFlatListBaseProps<ItemT> = React.ComponentProps<AnimatedFlatListType<ItemT>>;
 type AnimatedFlatListProps<ItemT> = AnimatedFlatListBaseProps<ItemT>;
 
+type FlatListWithHeadersProps<ItemT> = Omit<
+  AnimatedFlatListProps<ItemT> & SharedScrollContainerProps,
+  'onScroll'
+>;
+
 const FlatListWithHeadersInputComp = <ItemT extends unknown>(
   {
     largeHeaderShown,
@@ -30,6 +35,8 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
+    // We use this to ensure that the onScroll property isn't accidentally used.
+    // @ts-ignore
     onScroll: _unusedOnScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
@@ -40,9 +47,15 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
     scrollIndicatorInsets = {},
     inverted,
     ...rest
-  }: AnimatedFlatListProps<ItemT> & SharedScrollContainerProps,
+  }: FlatListWithHeadersProps<ItemT>,
   ref: React.Ref<Animated.FlatList<ItemT> | null>
 ) => {
+  if (_unusedOnScroll) {
+    throw new Error(
+      "The 'onScroll' property is not supported. Please use onScrollWorklet to track the scroll container's state."
+    );
+  }
+
   const insets = useSafeAreaInsets();
   const scrollRef = useAnimatedRef<Animated.FlatList<ItemT>>();
   useImperativeHandle(ref, () => scrollRef.current);
@@ -151,8 +164,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
 
 // The typecast is needed to make the component generic.
 const FlatListWithHeaders = React.forwardRef(FlatListWithHeadersInputComp) as <ItemT = any>(
-  props: AnimatedFlatListProps<ItemT> &
-    SharedScrollContainerProps & { ref?: React.Ref<Animated.FlatList<ItemT>> }
+  props: FlatListWithHeadersProps<ItemT> & { ref?: React.Ref<Animated.FlatList<ItemT>> }
 ) => React.ReactElement;
 
 export default FlatListWithHeaders;

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -23,9 +23,10 @@ const ScrollViewWithHeadersInputComp = (
     onLargeHeaderLayout,
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
-    onScroll,
+    onScroll: _unusedOnScroll,
     onScrollBeginDrag,
     onScrollEndDrag,
+    onScrollWorklet,
     onMomentumScrollBegin,
     onMomentumScrollEnd,
     disableAutoFixScroll = false,
@@ -62,6 +63,7 @@ const ScrollViewWithHeadersInputComp = (
     absoluteHeader,
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
+    onScrollWorklet,
   });
 
   return (
@@ -78,10 +80,7 @@ const ScrollViewWithHeadersInputComp = (
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={(e) => {
-          scrollHandler(e);
-          if (onScroll) onScroll(e);
-        }}
+        onScroll={scrollHandler}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -13,6 +13,11 @@ type AnimatedScrollViewProps = React.ComponentProps<typeof AnimatedScrollView> &
   children?: React.ReactNode;
 };
 
+type ScrollViewWithHeadersProps = Omit<
+  AnimatedScrollViewProps & SharedScrollContainerProps,
+  'onScroll'
+>;
+
 const ScrollViewWithHeadersInputComp = (
   {
     largeHeaderShown,
@@ -23,6 +28,8 @@ const ScrollViewWithHeadersInputComp = (
     onLargeHeaderLayout,
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
+    // We use this to ensure that the onScroll property isn't accidentally used.
+    // @ts-ignore
     onScroll: _unusedOnScroll,
     onScrollBeginDrag,
     onScrollEndDrag,
@@ -39,9 +46,15 @@ const ScrollViewWithHeadersInputComp = (
     scrollIndicatorInsets = {},
     disableLargeHeaderFadeAnim = false,
     ...rest
-  }: AnimatedScrollViewProps & SharedScrollContainerProps,
+  }: ScrollViewWithHeadersProps,
   ref: React.Ref<Animated.ScrollView | null>
 ) => {
+  if (_unusedOnScroll) {
+    throw new Error(
+      "The 'onScroll' property is not supported. Please use onScrollWorklet to track the scroll container's state."
+    );
+  }
+
   const insets = useSafeAreaInsets();
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   useImperativeHandle(ref, () => scrollRef.current);
@@ -146,10 +159,9 @@ const ScrollViewWithHeadersInputComp = (
   );
 };
 
-const ScrollViewWithHeaders = React.forwardRef<
-  Animated.ScrollView,
-  AnimatedScrollViewProps & SharedScrollContainerProps
->(ScrollViewWithHeadersInputComp);
+const ScrollViewWithHeaders = React.forwardRef<Animated.ScrollView, ScrollViewWithHeadersProps>(
+  ScrollViewWithHeadersInputComp
+);
 
 export default ScrollViewWithHeaders;
 

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -23,14 +23,13 @@ const ScrollViewWithHeadersInputComp = (
     onLargeHeaderLayout,
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
+    onScroll,
     onScrollBeginDrag,
     onScrollEndDrag,
     onMomentumScrollBegin,
     onMomentumScrollEnd,
     disableAutoFixScroll = false,
     children,
-    /** At the moment, we will not allow overriding of this since the scrollHandler needs it. */
-    onScroll: _unusedOnScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
     contentContainerStyle,
@@ -79,7 +78,10 @@ const ScrollViewWithHeadersInputComp = (
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={scrollHandler}
+        onScroll={(e) => {
+          scrollHandler(e);
+          if (onScroll) onScroll(e);
+        }}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/SectionList.tsx
+++ b/src/components/containers/SectionList.tsx
@@ -33,8 +33,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
-    /** At the moment, we will not allow overriding of this since the scrollHandler needs it. */
-    onScroll: _unusedOnScroll,
+    onScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
     contentContainerStyle,
@@ -85,7 +84,10 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={scrollHandler}
+        onScroll={(e) => {
+          scrollHandler(e);
+          if (onScroll) onScroll(e);
+        }}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/SectionList.tsx
+++ b/src/components/containers/SectionList.tsx
@@ -18,6 +18,11 @@ const AnimatedSectionList = Animated.createAnimatedComponent(SectionList) as Rea
   any
 >;
 
+type SectionListWithHeadersProps<ItemT, SectionT = DefaultSectionT> = Omit<
+  AnimatedSectionListType<ItemT, SectionT>,
+  'onScroll'
+>;
+
 const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = DefaultSectionT>(
   {
     largeHeaderShown,
@@ -34,6 +39,8 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
+    // We use this to ensure that the onScroll property isn't accidentally used.
+    // @ts-ignore
     onScroll: _unusedOnScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
@@ -44,9 +51,15 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     scrollIndicatorInsets = {},
     inverted,
     ...rest
-  }: AnimatedSectionListType<ItemT, SectionT>,
+  }: SectionListWithHeadersProps<ItemT, SectionT>,
   ref: React.Ref<Animated.ScrollView>
 ) => {
+  if (_unusedOnScroll) {
+    throw new Error(
+      "The 'onScroll' property is not supported. Please use onScrollWorklet to track the scroll container's state."
+    );
+  }
+
   const insets = useSafeAreaInsets();
   const scrollRef = useAnimatedRef<any>();
   useImperativeHandle(ref, () => scrollRef.current);
@@ -158,7 +171,7 @@ const SectionListWithHeaders = React.forwardRef(SectionListWithHeadersInputComp)
   ItemT = any,
   SectionT = DefaultSectionT
 >(
-  props: AnimatedSectionListType<ItemT, SectionT> & { ref?: React.Ref<Animated.ScrollView> }
+  props: SectionListWithHeadersProps<ItemT, SectionT> & { ref?: React.Ref<Animated.ScrollView> }
 ) => React.ReactElement;
 
 export default SectionListWithHeaders;

--- a/src/components/containers/SectionList.tsx
+++ b/src/components/containers/SectionList.tsx
@@ -28,12 +28,13 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     onLargeHeaderLayout,
     onScrollBeginDrag,
     onScrollEndDrag,
+    onScrollWorklet,
     onMomentumScrollBegin,
     onMomentumScrollEnd,
     ignoreLeftSafeArea,
     ignoreRightSafeArea,
     disableAutoFixScroll = false,
-    onScroll,
+    onScroll: _unusedOnScroll,
     absoluteHeader = false,
     initialAbsoluteHeaderHeight = 0,
     contentContainerStyle,
@@ -68,6 +69,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
     inverted: !!inverted,
+    onScrollWorklet,
   });
 
   return (
@@ -84,10 +86,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
         ref={scrollRef}
         scrollEventThrottle={16}
         overScrollMode="auto"
-        onScroll={(e) => {
-          scrollHandler(e);
-          if (onScroll) onScroll(e);
-        }}
+        onScroll={scrollHandler}
         automaticallyAdjustContentInsets={false}
         onScrollBeginDrag={(e) => {
           debouncedFixScroll.cancel();

--- a/src/components/containers/types.ts
+++ b/src/components/containers/types.ts
@@ -120,11 +120,6 @@ export type SharedScrollContainerProps = {
    */
   onMomentumScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   /**
-   * This property is not supported at the moment. Please use `onScrollWorklet` instead
-   * to track the scroll container's state with a reanimated worklet.
-   */
-  onScroll?: React.ComponentProps<typeof Animated.ScrollView>['onScroll'];
-  /**
    * A custom worklet that allows custom tracking scroll container's
    * state (i.e., its scroll contentInset, contentOffset, etc.). Please
    * ensure that this function is a [worklet](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/).

--- a/src/components/containers/types.ts
+++ b/src/components/containers/types.ts
@@ -120,14 +120,24 @@ export type SharedScrollContainerProps = {
    */
   onMomentumScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   /**
-   * A handler supplied to the scroll container to track the scroll state. This can be used in
-   * conjunction with [useAnimatedScrollHandler](https://docs.swmansion.com/react-native-reanimated/docs/scroll/useAnimatedScrollHandler)
-   * to track the scroll position on the UI thread.
-   *
-   * @note We use the FlatList's type definition for `onScroll` since the ScrollView type definition does not
-   * reference it.
+   * This property is not supported at the moment. Please use `onScrollWorklet` instead
+   * to track the scroll container's state with a reanimated worklet.
    */
-  onScroll?: React.ComponentProps<typeof Animated.FlatList>['onScroll'];
+  onScroll?: React.ComponentProps<typeof Animated.ScrollView>['onScroll'];
+  /**
+   * A custom worklet that allows custom tracking scroll container's
+   * state (i.e., its scroll contentInset, contentOffset, etc.). Please
+   * ensure that this function is a [worklet](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/worklets/).
+   *
+   * @example
+   * ```
+   * const scrollHandlerWorklet = (evt: NativeScrollEvent) => {
+   *   'worklet';
+   *   console.log('offset: ', evt.contentOffset);
+   * };
+   * ```
+   */
+  onScrollWorklet?: (evt: NativeScrollEvent) => void;
   /**
    * This property controls whether or not the header component is absolutely positioned.
    * This is useful if you want to render a header component that allows for transparency.

--- a/src/components/containers/types.ts
+++ b/src/components/containers/types.ts
@@ -120,10 +120,14 @@ export type SharedScrollContainerProps = {
    */
   onMomentumScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   /**
-   * This property is not supported at the moment. If you would like to listen to
-   * scroll events, use the useScrollViewOffset hook with a ref.
+   * A handler supplied to the scroll container to track the scroll state. This can be used in
+   * conjunction with [useAnimatedScrollHandler](https://docs.swmansion.com/react-native-reanimated/docs/scroll/useAnimatedScrollHandler)
+   * to track the scroll position on the UI thread.
+   *
+   * @note We use the FlatList's type definition for `onScroll` since the ScrollView type definition does not
+   * reference it.
    */
-  onScroll?: React.ComponentProps<typeof Animated.ScrollView>['onScroll'];
+  onScroll?: React.ComponentProps<typeof Animated.FlatList>['onScroll'];
   /**
    * This property controls whether or not the header component is absolutely positioned.
    * This is useful if you want to render a header component that allows for transparency.


### PR DESCRIPTION
## Description

Runs the user-provided onScroll function after react-native-header's scrollHandler

## Motivation and Context

[Issue](https://github.com/codeherence/react-native-header/issues/21#issue-1910310905)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have followed the guidelines in the README.md file.
- [X] I have updated the documentation as necessary.
- [X] My changes generate no new warnings.
