### PR TITLE
feat: add LargeHeaderSubtitleComponent

### DIFF
--- a/docs/docs/03-api-reference/01-scroll-view-with-headers.mdx
+++ b/docs/docs/03-api-reference/01-scroll-view-with-headers.mdx
@@ -44,6 +44,20 @@ following arguments:
   This prop is useful if you want to create your own custom animations based on whether or not the
   small header is hidden.
 
+### LargeHeaderSubtitleComponent
+
+An optional component to render typically as the second child of the ScrollView. This accepts a function that
+returns a React Element to display as the large header subtitle. The function will be called with the
+following arguments:
+
+- `scrollY`: An animated value that keeps track of the current scroll position of the ScrollView.
+  This prop is useful for creating custom animations on the large header. In our [example](/docs/example),
+  we use the [ScalingView](/docs/components/scaling-view) component to scale the large header
+  when the user pulls down on the ScrollView (to mimic native iOS behaviour).
+- `showNavBar`: An animated value that keeps track of whether or not the small header is hidden.
+  This prop is useful if you want to create your own custom animations based on whether or not the
+  small header is hidden.
+
 ### ignoreLeftSafeArea
 
 An optional boolean that determines whether or not to ignore the left safe area. Defaults to

--- a/docs/docs/03-api-reference/02-flat-list-with-headers.mdx
+++ b/docs/docs/03-api-reference/02-flat-list-with-headers.mdx
@@ -44,6 +44,20 @@ following arguments:
   This prop is useful if you want to create your own custom animations based on whether or not the
   small header is hidden.
 
+### LargeHeaderSubtitleComponent
+
+An optional component to render as a subtitle for the large header for this component. This accepts a function
+that returns a React Element to display as the large header subtitle. The function will be called with the
+following arguments:
+
+- `scrollY`: An animated value that keeps track of the current scroll position of the FlatList.
+  This prop is useful for creating custom animations on the large header. In our [example](/docs/example),
+  we use the [ScalingView](/docs/components/scaling-view) component to scale the large header
+  when the user pulls down on the FlatList (to mimic native iOS behaviour).
+- `showNavBar`: An animated value that keeps track of whether or not the small header is hidden.
+  This prop is useful if you want to create your own custom animations based on whether or not the
+  small header is hidden.
+
 ### ignoreLeftSafeArea
 
 An optional boolean that determines whether or not to ignore the left safe area. Defaults to

--- a/docs/docs/03-api-reference/03-section-list-with-headers.mdx
+++ b/docs/docs/03-api-reference/03-section-list-with-headers.mdx
@@ -44,6 +44,20 @@ following arguments:
   This prop is useful if you want to create your own custom animations based on whether or not the
   small header is hidden.
 
+### LargeHeaderSubtitleComponent
+
+An optional component to render as a subtitle for the large header for this component. This accepts a function
+that returns a React Element to display as the large header subtitle. The function will be called with the
+following arguments:
+
+- `scrollY`: An animated value that keeps track of the current scroll position of the FlatList.
+  This prop is useful for creating custom animations on the large header. In our [example](/docs/example),
+  we use the [ScalingView](/docs/components/scaling-view) component to scale the large header
+  when the user pulls down on the FlatList (to mimic native iOS behaviour).
+- `showNavBar`: An animated value that keeps track of whether or not the small header is hidden.
+  This prop is useful if you want to create your own custom animations based on whether or not the
+  small header is hidden.
+
 ### ignoreLeftSafeArea
 
 An optional boolean that determines whether or not to ignore the left safe area. Defaults to

--- a/docs/docs/03-api-reference/04-flash-list-with-headers.mdx
+++ b/docs/docs/03-api-reference/04-flash-list-with-headers.mdx
@@ -49,6 +49,20 @@ following arguments:
   This prop is useful if you want to create your own custom animations based on whether or not the
   small header is hidden.
 
+### LargeHeaderSubtitleComponent
+
+An optional component to render as a subtitle for the large header for this component. This accepts a function
+that returns a React Element to display as the large header subtitle. The function will be called with the
+following arguments:
+
+- `scrollY`: An animated value that keeps track of the current scroll position of the FlatList.
+  This prop is useful for creating custom animations on the large header. In our [example](/docs/example),
+  we use the [ScalingView](/docs/components/scaling-view) component to scale the large header
+  when the user pulls down on the FlatList (to mimic native iOS behaviour).
+- `showNavBar`: An animated value that keeps track of whether or not the small header is hidden.
+  This prop is useful if you want to create your own custom animations based on whether or not the
+  small header is hidden.
+
 ### ignoreLeftSafeArea
 
 An optional boolean that determines whether or not to ignore the left safe area. Defaults to

--- a/example/src/screens/usage/Simple.tsx
+++ b/example/src/screens/usage/Simple.tsx
@@ -3,7 +3,11 @@ import { RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Header, LargeHeader, ScrollViewWithHeaders } from '@codeherence/react-native-header';
-import type { ScrollHeaderProps, ScrollLargeHeaderProps } from '@codeherence/react-native-header';
+import type {
+  ScrollHeaderProps,
+  ScrollLargeHeaderProps,
+  ScrollLargeHeaderSubtitleProps,
+} from '@codeherence/react-native-header';
 import { range } from '../../utils';
 import { Avatar, BackButton } from '../../components';
 import { RANDOM_IMAGE_NUM } from '../../constants';
@@ -24,7 +28,12 @@ const HeaderComponent: React.FC<ScrollHeaderProps> = ({ showNavBar }) => {
       }
       headerRight={
         <TouchableOpacity onPress={onPressProfile}>
-          <Avatar size="sm" source={{ uri: `https://i.pravatar.cc/128?img=${RANDOM_IMAGE_NUM}` }} />
+          <Avatar
+            size="sm"
+            source={{
+              uri: `https://i.pravatar.cc/128?img=${RANDOM_IMAGE_NUM}`,
+            }}
+          />
         </TouchableOpacity>
       }
       headerRightFadesIn
@@ -46,6 +55,10 @@ const LargeHeaderComponent: React.FC<ScrollLargeHeaderProps> = () => {
   );
 };
 
+const LargeHeaderSubtitleComponent: React.FC<ScrollLargeHeaderSubtitleProps> = () => (
+  <Text style={styles.largeHeaderSubtitleStyle}>Scroll to see header animation</Text>
+);
+
 const Simple: React.FC<SimpleUsageScreenNavigationProps> = () => {
   const { bottom } = useSafeAreaInsets();
   const [refreshing, setRefreshing] = useState(false);
@@ -65,6 +78,7 @@ const Simple: React.FC<SimpleUsageScreenNavigationProps> = () => {
     <ScrollViewWithHeaders
       HeaderComponent={HeaderComponent}
       LargeHeaderComponent={LargeHeaderComponent}
+      LargeHeaderSubtitleComponent={LargeHeaderSubtitleComponent}
       contentContainerStyle={{ paddingBottom: bottom }}
       refreshControl={
         <RefreshControl refreshing={refreshing} colors={['#8E8E93']} onRefresh={onRefresh} />
@@ -72,7 +86,7 @@ const Simple: React.FC<SimpleUsageScreenNavigationProps> = () => {
     >
       <View style={styles.children}>
         {data.map((i) => (
-          <Text key={`text-${i}`}>Scroll to see header animation</Text>
+          <View key={`text-${i}`} style={styles.box} />
         ))}
       </View>
     </ScrollViewWithHeaders>
@@ -83,6 +97,17 @@ export default Simple;
 
 const styles = StyleSheet.create({
   children: { marginTop: 16, paddingHorizontal: 16 },
+  box: {
+    backgroundColor: 'lightgray',
+    height: 50,
+    marginVertical: 8,
+    borderRadius: 8,
+  },
   navBarTitle: { fontSize: 16, fontWeight: 'bold' },
   largeHeaderStyle: { flexDirection: 'row-reverse' },
+  largeHeaderSubtitleStyle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    paddingHorizontal: 16,
+  },
 });

--- a/src/components/containers/FlashList.tsx
+++ b/src/components/containers/FlashList.tsx
@@ -131,8 +131,8 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
           ...scrollIndicatorInsets,
         }}
         ListHeaderComponent={
-          LargeHeaderComponent ? (
-            <>
+          <>
+            {LargeHeaderComponent && (
               <View
                 onLayout={(e) => {
                   largeHeaderHeight.value = e.nativeEvent.layout.height;
@@ -150,10 +150,9 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
                   </View>
                 )}
               </View>
-              {LargeHeaderSubtitleComponent &&
-                LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
-            </>
-          ) : undefined
+            )}
+            {LargeHeaderSubtitleComponent && LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+          </>
         }
         inverted={inverted}
         {...rest}

--- a/src/components/containers/FlashList.tsx
+++ b/src/components/containers/FlashList.tsx
@@ -24,6 +24,7 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
   {
     largeHeaderShown,
     containerStyle,
+    LargeHeaderSubtitleComponent,
     LargeHeaderComponent,
     largeHeaderContainerStyle,
     HeaderComponent,
@@ -131,23 +132,27 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
         }}
         ListHeaderComponent={
           LargeHeaderComponent ? (
-            <View
-              onLayout={(e) => {
-                largeHeaderHeight.value = e.nativeEvent.layout.height;
+            <>
+              <View
+                onLayout={(e) => {
+                  largeHeaderHeight.value = e.nativeEvent.layout.height;
 
-                if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
-              }}
-            >
-              {!disableLargeHeaderFadeAnim ? (
-                <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </FadingView>
-              ) : (
-                <View style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </View>
-              )}
-            </View>
+                  if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
+                }}
+              >
+                {!disableLargeHeaderFadeAnim ? (
+                  <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
+                    {LargeHeaderComponent({ scrollY, showNavBar })}
+                  </FadingView>
+                ) : (
+                  <View style={largeHeaderContainerStyle}>
+                    {LargeHeaderComponent({ scrollY, showNavBar })}
+                  </View>
+                )}
+              </View>
+              {LargeHeaderSubtitleComponent &&
+                LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+            </>
           ) : undefined
         }
         inverted={inverted}
@@ -165,7 +170,9 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
 
 // The typecast is needed to make the component generic.
 const FlashListWithHeaders = React.forwardRef(FlashListWithHeadersInputComp) as <ItemT = any>(
-  props: FlashListWithHeadersProps<ItemT> & { ref?: React.RefObject<FlashList<ItemT>> }
+  props: FlashListWithHeadersProps<ItemT> & {
+    ref?: React.RefObject<FlashList<ItemT>>;
+  }
 ) => React.ReactElement;
 
 export default FlashListWithHeaders;

--- a/src/components/containers/FlatList.tsx
+++ b/src/components/containers/FlatList.tsx
@@ -130,8 +130,8 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
           ...scrollIndicatorInsets,
         }}
         ListHeaderComponent={
-          LargeHeaderComponent ? (
-            <>
+          <>
+            {LargeHeaderComponent && (
               <View
                 onLayout={(e) => {
                   largeHeaderHeight.value = e.nativeEvent.layout.height;
@@ -149,10 +149,9 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
                   </View>
                 )}
               </View>
-              {LargeHeaderSubtitleComponent &&
-                LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
-            </>
-          ) : undefined
+            )}
+            {LargeHeaderSubtitleComponent && LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+          </>
         }
         inverted={inverted}
         {...rest}

--- a/src/components/containers/FlatList.tsx
+++ b/src/components/containers/FlatList.tsx
@@ -23,6 +23,7 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
   {
     largeHeaderShown,
     containerStyle,
+    LargeHeaderSubtitleComponent,
     LargeHeaderComponent,
     largeHeaderContainerStyle,
     HeaderComponent,
@@ -130,23 +131,27 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
         }}
         ListHeaderComponent={
           LargeHeaderComponent ? (
-            <View
-              onLayout={(e) => {
-                largeHeaderHeight.value = e.nativeEvent.layout.height;
+            <>
+              <View
+                onLayout={(e) => {
+                  largeHeaderHeight.value = e.nativeEvent.layout.height;
 
-                if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
-              }}
-            >
-              {!disableLargeHeaderFadeAnim ? (
-                <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </FadingView>
-              ) : (
-                <View style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </View>
-              )}
-            </View>
+                  if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
+                }}
+              >
+                {!disableLargeHeaderFadeAnim ? (
+                  <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
+                    {LargeHeaderComponent({ scrollY, showNavBar })}
+                  </FadingView>
+                ) : (
+                  <View style={largeHeaderContainerStyle}>
+                    {LargeHeaderComponent({ scrollY, showNavBar })}
+                  </View>
+                )}
+              </View>
+              {LargeHeaderSubtitleComponent &&
+                LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+            </>
           ) : undefined
         }
         inverted={inverted}
@@ -164,7 +169,9 @@ const FlatListWithHeadersInputComp = <ItemT extends unknown>(
 
 // The typecast is needed to make the component generic.
 const FlatListWithHeaders = React.forwardRef(FlatListWithHeadersInputComp) as <ItemT = any>(
-  props: FlatListWithHeadersProps<ItemT> & { ref?: React.Ref<Animated.FlatList<ItemT>> }
+  props: FlatListWithHeadersProps<ItemT> & {
+    ref?: React.Ref<Animated.FlatList<ItemT>>;
+  }
 ) => React.ReactElement;
 
 export default FlatListWithHeaders;

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -130,28 +130,27 @@ const ScrollViewWithHeadersInputComp = (
         }}
         {...rest}
       >
-        {LargeHeaderComponent ? (
-          <>
-            <View
-              onLayout={(e) => {
-                largeHeaderHeight.value = e.nativeEvent.layout.height;
+        {LargeHeaderComponent && (
+          <View
+            onLayout={(e) => {
+              largeHeaderHeight.value = e.nativeEvent.layout.height;
 
-                if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
-              }}
-            >
-              {!disableLargeHeaderFadeAnim ? (
-                <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </FadingView>
-              ) : (
-                <View style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </View>
-              )}
-            </View>
-            {LargeHeaderSubtitleComponent && LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
-          </>
-        ) : null}
+              if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
+            }}
+          >
+            {!disableLargeHeaderFadeAnim ? (
+              <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
+                {LargeHeaderComponent({ scrollY, showNavBar })}
+              </FadingView>
+            ) : (
+              <View style={largeHeaderContainerStyle}>
+                {LargeHeaderComponent({ scrollY, showNavBar })}
+              </View>
+            )}
+          </View>
+        )}
+        {LargeHeaderSubtitleComponent && LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+
         {children}
       </AnimatedScrollView>
 

--- a/src/components/containers/ScrollView.tsx
+++ b/src/components/containers/ScrollView.tsx
@@ -22,6 +22,7 @@ const ScrollViewWithHeadersInputComp = (
   {
     largeHeaderShown,
     containerStyle,
+    LargeHeaderSubtitleComponent,
     LargeHeaderComponent,
     largeHeaderContainerStyle,
     HeaderComponent,
@@ -130,23 +131,26 @@ const ScrollViewWithHeadersInputComp = (
         {...rest}
       >
         {LargeHeaderComponent ? (
-          <View
-            onLayout={(e) => {
-              largeHeaderHeight.value = e.nativeEvent.layout.height;
+          <>
+            <View
+              onLayout={(e) => {
+                largeHeaderHeight.value = e.nativeEvent.layout.height;
 
-              if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
-            }}
-          >
-            {!disableLargeHeaderFadeAnim ? (
-              <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
-                {LargeHeaderComponent({ scrollY, showNavBar })}
-              </FadingView>
-            ) : (
-              <View style={largeHeaderContainerStyle}>
-                {LargeHeaderComponent({ scrollY, showNavBar })}
-              </View>
-            )}
-          </View>
+                if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
+              }}
+            >
+              {!disableLargeHeaderFadeAnim ? (
+                <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
+                  {LargeHeaderComponent({ scrollY, showNavBar })}
+                </FadingView>
+              ) : (
+                <View style={largeHeaderContainerStyle}>
+                  {LargeHeaderComponent({ scrollY, showNavBar })}
+                </View>
+              )}
+            </View>
+            {LargeHeaderSubtitleComponent && LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+          </>
         ) : null}
         {children}
       </AnimatedScrollView>

--- a/src/components/containers/SectionList.tsx
+++ b/src/components/containers/SectionList.tsx
@@ -134,8 +134,8 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
           ...scrollIndicatorInsets,
         }}
         ListHeaderComponent={
-          LargeHeaderComponent ? (
-            <>
+          <>
+            {LargeHeaderComponent && (
               <View
                 onLayout={(e) => {
                   largeHeaderHeight.value = e.nativeEvent.layout.height;
@@ -153,10 +153,9 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
                   </View>
                 )}
               </View>
-              {LargeHeaderSubtitleComponent &&
-                LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
-            </>
-          ) : undefined
+            )}
+            {LargeHeaderSubtitleComponent && LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+          </>
         }
         inverted={inverted}
         {...rest}

--- a/src/components/containers/SectionList.tsx
+++ b/src/components/containers/SectionList.tsx
@@ -27,6 +27,7 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
   {
     largeHeaderShown,
     containerStyle,
+    LargeHeaderSubtitleComponent,
     LargeHeaderComponent,
     largeHeaderContainerStyle,
     HeaderComponent,
@@ -134,23 +135,27 @@ const SectionListWithHeadersInputComp = <ItemT extends any = any, SectionT = Def
         }}
         ListHeaderComponent={
           LargeHeaderComponent ? (
-            <View
-              onLayout={(e) => {
-                largeHeaderHeight.value = e.nativeEvent.layout.height;
+            <>
+              <View
+                onLayout={(e) => {
+                  largeHeaderHeight.value = e.nativeEvent.layout.height;
 
-                if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
-              }}
-            >
-              {!disableLargeHeaderFadeAnim ? (
-                <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </FadingView>
-              ) : (
-                <View style={largeHeaderContainerStyle}>
-                  {LargeHeaderComponent({ scrollY, showNavBar })}
-                </View>
-              )}
-            </View>
+                  if (onLargeHeaderLayout) onLargeHeaderLayout(e.nativeEvent.layout);
+                }}
+              >
+                {!disableLargeHeaderFadeAnim ? (
+                  <FadingView opacity={largeHeaderOpacity} style={largeHeaderContainerStyle}>
+                    {LargeHeaderComponent({ scrollY, showNavBar })}
+                  </FadingView>
+                ) : (
+                  <View style={largeHeaderContainerStyle}>
+                    {LargeHeaderComponent({ scrollY, showNavBar })}
+                  </View>
+                )}
+              </View>
+              {LargeHeaderSubtitleComponent &&
+                LargeHeaderSubtitleComponent({ showNavBar, scrollY })}
+            </>
           ) : undefined
         }
         inverted={inverted}
@@ -171,7 +176,9 @@ const SectionListWithHeaders = React.forwardRef(SectionListWithHeadersInputComp)
   ItemT = any,
   SectionT = DefaultSectionT
 >(
-  props: SectionListWithHeadersProps<ItemT, SectionT> & { ref?: React.Ref<Animated.ScrollView> }
+  props: SectionListWithHeadersProps<ItemT, SectionT> & {
+    ref?: React.Ref<Animated.ScrollView>;
+  }
 ) => React.ReactElement;
 
 export default SectionListWithHeaders;

--- a/src/components/containers/index.ts
+++ b/src/components/containers/index.ts
@@ -7,5 +7,6 @@ export { default as FlashListWithHeaders } from './FlashList';
 export type {
   ScrollHeaderProps,
   ScrollLargeHeaderProps,
+  ScrollLargeHeaderSubtitleProps,
   SharedScrollContainerProps,
 } from './types';

--- a/src/components/containers/types.ts
+++ b/src/components/containers/types.ts
@@ -26,6 +26,25 @@ export interface ScrollLargeHeaderProps {
   showNavBar: Animated.SharedValue<number>;
 }
 
+/**
+ * The props supplied to the large header subtitle component of this scroll container.
+ */
+export interface ScrollLargeHeaderSubtitleProps {
+  /**
+   * The scroll position of the scroll view.
+   *
+   * @type {Animated.SharedValue<number>}
+   */
+  scrollY: Animated.SharedValue<number>;
+  /**
+   * Animated value between 0 and 1 that indicates whether the small header's content should be
+   * visible. This is used to animate the header's content in and out.
+   *
+   * @type {Animated.SharedValue<number>}
+   */
+  showNavBar: Animated.SharedValue<number>;
+}
+
 export interface ScrollHeaderProps {
   /**
    * Animated value between 0 and 1 that indicates whether the small header's content should be
@@ -59,6 +78,13 @@ export type SharedScrollContainerProps = {
    * @returns {React.ReactNode}
    */
   LargeHeaderComponent?: (props: ScrollLargeHeaderProps) => React.ReactNode;
+  /**
+   * The subtitle component for the large header component. This is the component that is rendered below the large header component.
+   *
+   * @param {ScrollLargeHeaderSubtitleProps} props The props given to the large header subtitle component.
+   * @returns {React.ReactNode}
+   */
+  LargeHeaderSubtitleComponent?: (props: ScrollLargeHeaderSubtitleProps) => React.ReactNode;
   /**
    * The small header component. This is the component that is rendered on top of the scroll view.
    *

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export {
 export type {
   ScrollHeaderProps,
   ScrollLargeHeaderProps,
+  ScrollLargeHeaderSubtitleProps,
   SharedScrollContainerProps,
 } from './containers';
 export { Header, LargeHeader } from './headers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type {
   LargeHeaderProps,
   ScrollHeaderProps,
   ScrollLargeHeaderProps,
+  ScrollLargeHeaderSubtitleProps,
   SharedScrollContainerProps,
   SurfaceComponentProps,
 } from './components';


### PR DESCRIPTION
## Description

Closes #24. Adds a LargeHeaderSubtitleComponent to all the containers so that a component can be added to the ListHeaderComponent/ScrollView.

## Motivation and Context

I would like to add additional components to the ListHeader that don't get impact the header animation. For example, several lines of text. 

## How Has This Been Tested?

This has been tested in both the Simple ScrollView and the FlatList in the example. I have added the subtitle to the ScrollView for future testing. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have followed the guidelines in the README.md file.
- [x] I have updated the documentation as necessary.
- [x] My changes generate no new warnings.

<!-- Delete this section if it is not relevant. -->
## Screenshots


![Simulator Screenshot - iPhone 15 Pro - 2024-03-01 at 10 39 10](https://github.com/codeherence/react-native-header/assets/45667737/dcb66989-04b2-44e1-a145-10b6e380762d)


<!-- Delete this section if it is not relevant. -->
## Additional Notes (Optional)

Please include any additional information or context that may be helpful for the reviewer.
