### PR TITLE
feat: introduce bottom border color interpolation

### DIFF
--- a/docs/docs/03-api-reference/05-header.mdx
+++ b/docs/docs/03-api-reference/05-header.mdx
@@ -73,6 +73,11 @@ you should set this to `true`.
 An optional boolean to indicate whether the header should not have a bottom border. Defaults to
 `false`.
 
+### initialBorderColor
+
+An optional color to use for the header's bottom border color initially. When the user scrolls down,
+the color will animate to the supplied [borderColor](/docs/components/header#bordercolor). Defaults to `#E5E5E5`.
+
 ### borderColor
 
 An optional color to use for the header's bottom border. Defaults to `#E5E5E5`.

--- a/example/src/screens/usage/Simple.tsx
+++ b/example/src/screens/usage/Simple.tsx
@@ -21,6 +21,8 @@ const HeaderComponent: React.FC<ScrollHeaderProps> = ({ showNavBar }) => {
     <Header
       showNavBar={showNavBar}
       headerCenterFadesIn={false}
+      borderColor="red"
+      initialBorderColor="blue"
       headerCenter={
         <Text style={styles.navBarTitle} numberOfLines={1}>
           Header
@@ -79,6 +81,8 @@ const Simple: React.FC<SimpleUsageScreenNavigationProps> = () => {
       HeaderComponent={HeaderComponent}
       LargeHeaderComponent={LargeHeaderComponent}
       LargeHeaderSubtitleComponent={LargeHeaderSubtitleComponent}
+      automaticallyAdjustsScrollIndicatorInsets={false}
+      scrollIndicatorInsets={{ bottom }}
       contentContainerStyle={{ paddingBottom: bottom }}
       refreshControl={
         <RefreshControl refreshing={refreshing} colors={['#8E8E93']} onRefresh={onRefresh} />

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
     "singleQuote": true,
     "tabWidth": 2,
     "trailingComma": "es5",
-    "useTabs": false
+    "useTabs": false,
+    "printWidth": 100
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/src/components/headers/Header.tsx
+++ b/src/components/headers/Header.tsx
@@ -23,6 +23,7 @@ const Header: React.FC<HeaderProps> = ({
   noBottomBorder = false,
   ignoreTopSafeArea = false,
   borderColor,
+  initialBorderColor,
   borderWidth,
   SurfaceComponent,
 }) => {
@@ -113,6 +114,7 @@ const Header: React.FC<HeaderProps> = ({
         <HeaderBottomBorder
           opacity={showNavBar}
           borderColor={borderColor}
+          initialBorderColor={initialBorderColor}
           borderWidth={borderWidth}
         />
       )}

--- a/src/components/headers/types.ts
+++ b/src/components/headers/types.ts
@@ -108,6 +108,13 @@ export interface HeaderProps {
    */
   noBottomBorder?: boolean;
   /**
+   * The color of the border when the header is not scrolled up.
+   *
+   * @default '#E5E5E5'
+   * @type {string}
+   */
+  initialBorderColor?: string;
+  /**
    * The color of the bottom border.
    *
    * @default '#E5E5E5'

--- a/src/components/line/HeaderBottomBorder.tsx
+++ b/src/components/line/HeaderBottomBorder.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import Animated, { interpolateColor, useAnimatedStyle } from 'react-native-reanimated';
 
 interface HeaderBottomBorderProps {
   /**
@@ -13,6 +13,10 @@ interface HeaderBottomBorderProps {
    * Style of the bottom border component.
    */
   style?: StyleProp<ViewStyle>;
+  /**
+   *
+   */
+  initialBorderColor?: string;
   /**
    * Color of the bottom border.
    *
@@ -30,21 +34,18 @@ interface HeaderBottomBorderProps {
 const HeaderBottomBorder: React.FC<HeaderBottomBorderProps> = ({
   opacity,
   style,
+  initialBorderColor = '#E5E5E5',
   borderColor = '#E5E5E5',
   borderWidth = 1,
 }) => {
-  const borderBottomStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
-
-  return (
-    <Animated.View
-      style={[
-        styles.line,
-        borderBottomStyle,
-        { height: borderWidth, backgroundColor: borderColor },
-        style,
-      ]}
-    />
+  const borderBottomStyle = useAnimatedStyle(
+    () => ({
+      backgroundColor: interpolateColor(opacity.value, [0, 1], [initialBorderColor, borderColor]),
+    }),
+    [initialBorderColor, borderColor]
   );
+
+  return <Animated.View style={[styles.line, borderBottomStyle, { height: borderWidth }, style]} />;
 };
 
 export default HeaderBottomBorder;


### PR DESCRIPTION
## Description

- Introduced a new prop `initialBorderColor` in the `Header` component to allow users to set the color of the bottom border.
- Ensured that the bottom border color animates between the initial color and the final color when the scroll container is scrolled down.

## Motivation and Context

This feature was added to allow for the animating between different border colors during the animation that is triggered on scroll.

## How Has This Been Tested?

This was mainly tested in the example repo manually.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have followed the guidelines in the README.md file.
- [x] I have updated the documentation as necessary.
- [x] My changes generate no new warnings.
