### PR TITLE
fix: allows header style overriding

### DIFF
--- a/src/components/headers/Header.tsx
+++ b/src/components/headers/Header.tsx
@@ -50,9 +50,9 @@ const Header: React.FC<HeaderProps> = ({
             opacity={showNavBar}
             style={[
               styles.leftContainer,
-              headerLeftStyle,
               noHeaderLeftRight && styles.noFlex,
               { width: minSideHeaderWidth },
+              headerLeftStyle,
             ]}
           >
             {headerLeft}
@@ -61,9 +61,9 @@ const Header: React.FC<HeaderProps> = ({
           <View
             style={[
               styles.leftContainer,
-              headerLeftStyle,
               noHeaderLeftRight && styles.noFlex,
               { width: minSideHeaderWidth },
+              headerLeftStyle,
             ]}
           >
             {headerLeft}
@@ -74,12 +74,12 @@ const Header: React.FC<HeaderProps> = ({
           (headerCenterFadesIn ? (
             <FadingView
               opacity={showNavBar}
-              style={[styles.centerContainer, headerCenterStyle, { minWidth: centerWidth }]}
+              style={[styles.centerContainer, { minWidth: centerWidth }, headerCenterStyle]}
             >
               {headerCenter}
             </FadingView>
           ) : (
-            <View style={[styles.centerContainer, headerCenterStyle, { width: centerWidth }]}>
+            <View style={[styles.centerContainer, { width: centerWidth }, headerCenterStyle]}>
               {headerCenter}
             </View>
           ))}
@@ -89,9 +89,9 @@ const Header: React.FC<HeaderProps> = ({
             opacity={showNavBar}
             style={[
               styles.rightContainer,
-              headerRightStyle,
               noHeaderLeftRight && styles.noFlex,
               { width: minSideHeaderWidth },
+              headerRightStyle,
             ]}
           >
             {headerRight}
@@ -100,9 +100,9 @@ const Header: React.FC<HeaderProps> = ({
           <View
             style={[
               styles.rightContainer,
-              headerRightStyle,
               noHeaderLeftRight && styles.noFlex,
               { width: minSideHeaderWidth },
+              headerRightStyle,
             ]}
           >
             {headerRight}

--- a/src/components/headers/Header.tsx
+++ b/src/components/headers/Header.tsx
@@ -44,7 +44,7 @@ const Header: React.FC<HeaderProps> = ({
     <View>
       {SurfaceComponent && SurfaceComponent({ showNavBar })}
 
-      <View style={[styles.container, headerStyle, !ignoreTopSafeArea && { paddingTop: top }]}>
+      <View style={[styles.container, !ignoreTopSafeArea && { paddingTop: top }, headerStyle]}>
         {headerLeftFadesIn ? (
           <FadingView
             opacity={showNavBar}


### PR DESCRIPTION
## Description

This change allows the `Header` styles to be fully overriden from the outside, including the internally calculated dimensions for the left, center and right containers.

## Motivation and Context

It's a common approach to let the consumer override the styles from the outside by placing the style prop last, so that the users of the component can do whatever they want with the internal containers, even to override the inner `width` and `minWidth` that the component calculates. Besides that, it opens some other interesting options, like freely customizing the `headerStyle` with flex options to play along with its containers.

As a practical example imagine the need for the title container to occupy most of the horizontal space of the header, rather than 1/3 as it is now, before this change, setting a `width` or `minWidth` wouldn't have any effect, as the internal calculation will always prevail by precedence, same for flex options, as they are ignored with fixed widths.

## How Has This Been Tested?

I have tested these changes in my own app, where I was able to override the styles by setting the `width` and `minWidth`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have followed the guidelines in the README.md file.
- [x] I have updated the documentation as necessary.
- [x] My changes generate no new warnings.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/96d78e60-7461-41c3-85ca-972d9d0c3753)

### After

![image](https://github.com/user-attachments/assets/4f4c349e-b878-428c-a6aa-f8233a2f1014)

The code for the results above:

```ts
headerLeftStyle={{
  backgroundColor: 'red',
  minWidth: undefined,
  width: undefined,
}}
headerCenterStyle={{
  backgroundColor: 'green',
  minWidth: undefined,
  width: undefined,
}}
headerRightStyle={{
  backgroundColor: 'blue',
  minWidth: undefined,
  width: undefined,
}}
```

## Additional Notes (Optional)

I consider this as a breaking change because people might have set custom styles on those containers that were being ignored until now, and will from now on be properly respected.

By unsetting the `width` and `minWidth` it may come with a tradeoff of poor header container alignments, like the title not being centered for uneven edges, but it's up to developer to adjust that if it's a deliberate decision to override those (like in my case). I do a custom calculation of the side container dimensions based on the larger edge width, that way it ensures that when the containers are uneven it will always make sure that the title container has the same distance to both edges and therefore the title can be center aligned if needed. This could be an interesting future improvement for the package, even more if you plan to support left aligned (android) or expanded center containers.

```ts
const [leftDimensions, onLeftLayout] = useComponentDimensions();
const [rightDimensions, onRightLayout] = useComponentDimensions();

const largerEdgeWidth = leftAligned
    ? undefined
    : Math.max(leftDimensions.width, rightDimensions.width);

// then on the side components style I do the following to guarantee that the title is always properly aligned.
minWidth: largerEdgeWidth
```