### PR TITLE
fix: flashlist inverted handling

### DIFF
--- a/example/src/screens/usage/FlatList.tsx
+++ b/example/src/screens/usage/FlatList.tsx
@@ -83,6 +83,7 @@ const FlatList: React.FC<FlatListUsageScreenNavigationProps> = () => {
       data={data}
       renderItem={renderItem}
       windowSize={10}
+      automaticallyAdjustsScrollIndicatorInsets={false}
       getItemLayout={(_, index) => ({ index, length: ITEM_HEIGHT, offset: index * ITEM_HEIGHT })}
       initialNumToRender={50}
       maxToRenderPerBatch={100}

--- a/example/src/screens/usage/Inverted.tsx
+++ b/example/src/screens/usage/Inverted.tsx
@@ -3,13 +3,12 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { randParagraph, randUuid } from '@ngneat/falso';
 import { BlurView } from 'expo-blur';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import {
   Header,
   ScrollHeaderProps,
-  FlatListWithHeaders,
   SurfaceComponentProps,
+  FlashListWithHeaders,
 } from '@codeherence/react-native-header';
 import { Avatar, BackButton } from '../../components';
 import { RANDOM_IMAGE_NUM } from '../../constants';
@@ -68,20 +67,23 @@ const ChatMessage: React.FC<ChatMessage> = ({ message, type }) => {
 };
 
 const Inverted: React.FC<InvertedUsageScreenNavigationProps> = () => {
-  const { bottom } = useSafeAreaInsets();
-
   return (
     <>
       <StatusBar style="light" />
-      <FlatListWithHeaders
+      <FlashListWithHeaders
         data={data}
         renderItem={({ item }) => <ChatMessage {...item} />}
         HeaderComponent={HeaderComponent}
         keyExtractor={(item) => item.id}
-        inverted
+        // inverted
         absoluteHeader
         containerStyle={styles.container}
-        contentContainerStyle={[styles.contentContainer, { paddingTop: bottom }]}
+        maintainVisibleContentPosition={{
+          startRenderingFromBottom: true,
+        }}
+        automaticallyAdjustsScrollIndicatorInsets={false}
+        // eslint-disable-next-line react-native/no-inline-styles
+        contentContainerStyle={{ paddingHorizontal: 12 }}
         showsVerticalScrollIndicator
         indicatorStyle={'white'}
       />
@@ -93,6 +95,7 @@ export default Inverted;
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     backgroundColor: 'black',
   },
   contentContainer: {

--- a/src/components/containers/FlashList.tsx
+++ b/src/components/containers/FlashList.tsx
@@ -1,7 +1,7 @@
-import React, { useImperativeHandle } from 'react';
+import React, { useImperativeHandle, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Animated, { AnimatedProps, useAnimatedRef } from 'react-native-reanimated';
+import Animated, { AnimatedProps, isSharedValue, useAnimatedRef } from 'react-native-reanimated';
 import { FlashList, FlashListProps, FlashListRef } from '@shopify/flash-list';
 
 import type { SharedScrollContainerProps } from '.';
@@ -60,6 +60,17 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
   const scrollRef = useAnimatedRef<any>();
   useImperativeHandle(ref, () => scrollRef.current);
 
+  const { maintainVisibleContentPosition } = rest;
+  const inverted = useMemo(() => {
+    if (maintainVisibleContentPosition === undefined) return false;
+    if (isSharedValue(maintainVisibleContentPosition)) return false;
+
+    return (
+      (maintainVisibleContentPosition as FlashListProps<ItemT>['maintainVisibleContentPosition'])
+        ?.startRenderingFromBottom ?? false
+    );
+  }, [maintainVisibleContentPosition]);
+
   const {
     scrollY,
     showNavBar,
@@ -77,8 +88,9 @@ const FlashListWithHeadersInputComp = <ItemT extends any = any>(
     absoluteHeader,
     initialAbsoluteHeaderHeight,
     headerFadeInThreshold,
-    inverted: false,
+    inverted,
     onScrollWorklet,
+    isFlashList: true,
   });
 
   return (


### PR DESCRIPTION
## Description

This changes introduces a fix for FlashList inverted handling since [it was refactored in v2](https://shopify.github.io/flash-list/docs/v2-migration#other-deprecated-props).

## Motivation and Context

@ythomop pointed out that the new implementation was using the deprecated field. Thank you!

## How Has This Been Tested?

Refactored the inverted example in the `example` application to make use of this new prop.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have followed the guidelines in the README.md file.
- [x] I have updated the documentation as necessary.
- [x] My changes generate no new warnings.